### PR TITLE
Fix string values not getting updated after the first time

### DIFF
--- a/MSFSTouchPortalPlugin/Services/PluginService.cs
+++ b/MSFSTouchPortalPlugin/Services/PluginService.cs
@@ -191,8 +191,6 @@ namespace MSFSTouchPortalPlugin.Services {
           // Handle conversions
           if (Units.ShouldConvertToFloat(value.Unit)) {
             valObj = float.Parse(stringVal);
-          } else if (value.Unit == Units.String) {
-            valObj = ((StringVal64)data).Value;
           } else if (value.Unit == Units.radians) {
             // Convert to Degrees
             valObj = float.Parse(stringVal) * (180 / Math.PI);

--- a/MSFSTouchPortalPlugin/Services/SimConnectService.cs
+++ b/MSFSTouchPortalPlugin/Services/SimConnectService.cs
@@ -232,8 +232,9 @@ namespace MSFSTouchPortalPlugin.Services {
     [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 64)]
     public string Value;
 
-    public bool Equals(StringVal64 other) {
-      return other.Value == Value;
-    }
+    public bool Equals(StringVal64 other) => other.Value == Value;
+    public override bool Equals(object obj) => (obj is StringVal64 && Equals((StringVal64)obj));
+    public override string ToString() => Value;
+    public override int GetHashCode() => Value.GetHashCode();
   }
 }


### PR DESCRIPTION
Strings like ATC data and aircraft title were only detected as "changed" the first time they were received from SimConnect.  

For string values, the `value.Value != stringVal` comparison was actually working on the data type (String64) not the actual data. With the `String64` class "fully" defined the explicit conversion is no longer needed either.

Fixes https://github.com/tlewis17/MSFSTouchPortalPlugin/issues/42

This is the first in a few PRs I'm about to submit. They're mostly each small and I'm not sure if it would be easier as one PR or individual ones (all the commits are separate already).  So let me know if you'd prefer some other strategy.

I also plan to publish a test version on my fork, for anyone who wants to give it a go w/out a build environment.

Cheers,
-Max