### PR TITLE
Fix Connect/Disconnect/Toggle SimConnect actions and add graceful reconnect on errors.

### DIFF
--- a/MSFSTouchPortalPlugin/Services/PluginService.cs
+++ b/MSFSTouchPortalPlugin/Services/PluginService.cs
@@ -211,7 +211,7 @@ namespace MSFSTouchPortalPlugin.Services {
     }
 
     private void SimConnectEvent_OnDisconnect() {
-      _simConnectCancellationTokenSource.Cancel();
+      _simConnectCancellationTokenSource?.Cancel();
       _client.StateUpdate("MSFSTouchPortalPlugin.Plugin.State.Connected", _simConnectService.IsConnected().ToString().ToLower());
     }
 
@@ -224,10 +224,16 @@ namespace MSFSTouchPortalPlugin.Services {
     }
 
     private Task TryConnect() {
-
+      short i = 0;
       while (!_cancellationToken.IsCancellationRequested) {
         if (autoReconnectSimConnect && !_simConnectService.IsConnected()) {
-          _simConnectService.Connect();
+          if (i == 0) {
+            if (!_simConnectService.Connect())
+              i = 10;  // delay reconnect attempt on error
+          }
+          else {
+            --i;
+          }
         }
 
         // SimConnect is typically available even before loading into a flight. This should connect and be ready by the time a flight is started.

--- a/MSFSTouchPortalPlugin/Services/PluginService.cs
+++ b/MSFSTouchPortalPlugin/Services/PluginService.cs
@@ -28,6 +28,7 @@ namespace MSFSTouchPortalPlugin.Services {
     private readonly ITouchPortalClient _client;
     private readonly ISimConnectService _simConnectService;
     private readonly IReflectionService _reflectionService;
+    private bool autoReconnectSimConnect = true;
 
     public string PluginId => "MSFSTouchPortalPlugin";
     private readonly IReadOnlyCollection<Setting> _settings;
@@ -104,6 +105,7 @@ namespace MSFSTouchPortalPlugin.Services {
 
       _hostApplicationLifetime.ApplicationStopping.Register(() => {
         // Disconnect from SimConnect
+        autoReconnectSimConnect = false;
         _simConnectService.Disconnect();
       });
 
@@ -222,16 +224,13 @@ namespace MSFSTouchPortalPlugin.Services {
     }
 
     private Task TryConnect() {
-      int i = 0;
 
       while (!_cancellationToken.IsCancellationRequested) {
-        if (i == 0 && !_simConnectService.IsConnected()) {
+        if (autoReconnectSimConnect && !_simConnectService.IsConnected()) {
           _simConnectService.Connect();
-          i = 10;
         }
 
         // SimConnect is typically available even before loading into a flight. This should connect and be ready by the time a flight is started.
-        i--;
         Thread.Sleep(1000);
       }
 
@@ -246,18 +245,20 @@ namespace MSFSTouchPortalPlugin.Services {
         switch (internalEventResult) {
           case Plugin.ToggleConnection:
             if (_simConnectService.IsConnected()) {
+              autoReconnectSimConnect = false;
               _simConnectService.Disconnect();
             } else {
-              _simConnectService.Connect();
+              autoReconnectSimConnect = true;
             }
             break;
           case Plugin.Connect:
             if (!_simConnectService.IsConnected()) {
-              _simConnectService.Connect();
+              autoReconnectSimConnect = true;
             }
             break;
           case Plugin.Disconnect:
             if (_simConnectService.IsConnected()) {
+              autoReconnectSimConnect = false;
               _simConnectService.Disconnect();
             }
             break;

--- a/MSFSTouchPortalPlugin/Services/SimConnectService.cs
+++ b/MSFSTouchPortalPlugin/Services/SimConnectService.cs
@@ -114,8 +114,14 @@ namespace MSFSTouchPortalPlugin.Services {
 
     public bool TransmitClientEvent(Groups group, Enum eventId, uint data) {
       if (_connected) {
-        _simConnect.TransmitClientEvent(SimConnect.SIMCONNECT_OBJECT_ID_USER, eventId, data, group, SIMCONNECT_EVENT_FLAG.GROUPID_IS_PRIORITY);
-        return true;
+        try {
+          _simConnect.TransmitClientEvent(SimConnect.SIMCONNECT_OBJECT_ID_USER, eventId, data, group, SIMCONNECT_EVENT_FLAG.GROUPID_IS_PRIORITY);
+          return true;
+        }
+        catch (Exception ex) {
+          _logger.LogError(ex, $"TransmitClientEvent({group}, {eventId}, {data}) failed, disconnecting.");
+          Disconnect();
+        }
       }
 
       return false;
@@ -148,7 +154,14 @@ namespace MSFSTouchPortalPlugin.Services {
 
     public bool RequestDataOnSimObjectType(SimVarItem simVar) {
       if (_connected) {
-        _simConnect.RequestDataOnSimObjectType(simVar.Def, simVar.Def, 0, SIMCONNECT_SIMOBJECT_TYPE.USER);
+        try {
+          _simConnect.RequestDataOnSimObjectType(simVar.Def, simVar.Def, 0, SIMCONNECT_SIMOBJECT_TYPE.USER);
+          return true;
+        }
+        catch (Exception ex) {
+          _logger.LogError(ex, $"RequestDataOnSimObjectType({simVar.Def}) failed, disconnecting.");
+          Disconnect();
+        }
       }
 
       return false;


### PR DESCRIPTION
Since `TryConnect()` kept running in the background, actually disconnecting from the sim manually (with the TP actions) didn't work (or it would, but it would just reconnect again).

Also when MSFS/SimConnect crashed, the whole plugin had to be restarted in many/most cases. This detects a couple unexpected errors during communication and automatically disconnects. Whereby `TryConnect()` should resume the connection ASAP.
