### PR TITLE
Consolidate all logging to Serilog

### DIFF
--- a/MSFSTouchPortalPlugin/MSFSTouchPortalPlugin.csproj
+++ b/MSFSTouchPortalPlugin/MSFSTouchPortalPlugin.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
@@ -26,13 +26,14 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="5.0.1" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="5.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="5.0.0" />
-    <PackageReference Include="Serilog.Extensions.Logging" Version="3.0.1" />
-    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
-    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.20.0.28934">
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
+    <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
+    <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="4.0.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="8.34.0.42011">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/MSFSTouchPortalPlugin/appsettings.json
+++ b/MSFSTouchPortalPlugin/appsettings.json
@@ -1,8 +1,28 @@
 {
-  "Logging": {
-    "LogLevel": {
-      "Default": "Information",
-      "Microsoft": "Warning"
+  "Serilog": {
+    "Using": [ "Serilog.Sinks.File", "Serilog.Sinks.Console" ],
+    "WriteTo": [
+      {
+        "Name": "File",
+        "Args": {
+          "path": "logs/MSFSTouchPortalPlugin.log",
+          "rollingInterval": "Day"
+        }
+      },
+      {
+        "Name": "Console",
+        "Args": {
+          "outputTemplate": "[{Timestamp:MM.dd HH:mm:ss}] [{Level:u3}] {SourceContext} {NewLine}      {Message:lj} {NewLine}{Exception}"
+        }
+      }
+    ],
+    "MinimumLevel": {
+      "Default": "Warning",
+      "Override": {
+        "Microsoft": "Warning",
+        "TouchPortalSDK": "Warning",
+        "MSFSTouchPortalPlugin": "Information"
+      }
     }
   },
   "TouchPortalOptions": {

--- a/MSFSTouchPortalPlugin/appsettings.json
+++ b/MSFSTouchPortalPlugin/appsettings.json
@@ -6,7 +6,8 @@
         "Name": "File",
         "Args": {
           "path": "logs/MSFSTouchPortalPlugin.log",
-          "rollingInterval": "Day"
+          "rollingInterval": "Day",
+          "retainedFileCountLimit": 7
         }
       },
       {


### PR DESCRIPTION
* Prettier console output, configurable from `appsettings.json` 
* Live reload of logging settings from `appsettings.json` (w/out restarting plugin)
* Reduce TouchPortalSDK logging level to Warning (was spamming logs with "state updated" messages)
* Also update Microsoft Extensions and SonarAnalyzer to latest versions.