### PR TITLE
Update project/build files

### DIFF
--- a/MSFSTouchPortalPlugin-Generator/MSFSTouchPortalPlugin-Generator.csproj
+++ b/MSFSTouchPortalPlugin-Generator/MSFSTouchPortalPlugin-Generator.csproj
@@ -5,6 +5,12 @@
     <TargetFramework>net5.0</TargetFramework>
     <RootNamespace>MSFSTouchPortalPlugin_Generator</RootNamespace>
     <CodeAnalysisRuleSet>..\.sonarlint\msfstouchportalplugincsharp.ruleset</CodeAnalysisRuleSet>
+    <Platforms>x64</Platforms>
+    <Version>1.1.0</Version>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <NoWarn>1701;1702;S125;CS8032</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MSFSTouchPortalPlugin-Generator/Properties/launchSettings.json
+++ b/MSFSTouchPortalPlugin-Generator/Properties/launchSettings.json
@@ -1,7 +1,8 @@
 {
   "profiles": {
     "MSFSTouchPortalPlugin-Generator": {
-      "commandName": "Project"
+      "commandName": "Project",
+      "commandLineArgs": "..\\..\\..\\..\\..\\"
     }
   }
 }

--- a/MSFSTouchPortalPlugin-Tests/MSFSTouchPortalPlugin-Tests.csproj
+++ b/MSFSTouchPortalPlugin-Tests/MSFSTouchPortalPlugin-Tests.csproj
@@ -5,6 +5,8 @@
     <RootNamespace>MSFSTouchPortalPlugin_Tests</RootNamespace>
 
     <IsPackable>false</IsPackable>
+
+    <Platforms>x64</Platforms>
   </PropertyGroup>
 
   <ItemGroup>

--- a/MSFSTouchPortalPlugin.sln
+++ b/MSFSTouchPortalPlugin.sln
@@ -46,26 +46,26 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MSFSTouchPortalPlugin-Tests
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
-		Debug|Any CPU = Debug|Any CPU
-		Release|Any CPU = Release|Any CPU
+		Debug|x64 = Debug|x64
+		Release|x64 = Release|x64
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{D3F1B2FB-0846-4003-8D2E-355273668F37}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{D3F1B2FB-0846-4003-8D2E-355273668F37}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{D3F1B2FB-0846-4003-8D2E-355273668F37}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{D3F1B2FB-0846-4003-8D2E-355273668F37}.Release|Any CPU.Build.0 = Release|Any CPU
-		{53A38611-6486-4FF5-8637-1C6BC38A6A18}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{53A38611-6486-4FF5-8637-1C6BC38A6A18}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{53A38611-6486-4FF5-8637-1C6BC38A6A18}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{53A38611-6486-4FF5-8637-1C6BC38A6A18}.Release|Any CPU.Build.0 = Release|Any CPU
-		{C217E7C3-4A14-457E-ABC8-180546369646}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{C217E7C3-4A14-457E-ABC8-180546369646}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{C217E7C3-4A14-457E-ABC8-180546369646}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{C217E7C3-4A14-457E-ABC8-180546369646}.Release|Any CPU.Build.0 = Release|Any CPU
-		{562A58FF-DD9A-4839-B503-4520D3BE96DA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{562A58FF-DD9A-4839-B503-4520D3BE96DA}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{562A58FF-DD9A-4839-B503-4520D3BE96DA}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{562A58FF-DD9A-4839-B503-4520D3BE96DA}.Release|Any CPU.Build.0 = Release|Any CPU
+		{D3F1B2FB-0846-4003-8D2E-355273668F37}.Debug|x64.ActiveCfg = Debug|x64
+		{D3F1B2FB-0846-4003-8D2E-355273668F37}.Debug|x64.Build.0 = Debug|x64
+		{D3F1B2FB-0846-4003-8D2E-355273668F37}.Release|x64.ActiveCfg = Release|x64
+		{D3F1B2FB-0846-4003-8D2E-355273668F37}.Release|x64.Build.0 = Release|x64
+		{53A38611-6486-4FF5-8637-1C6BC38A6A18}.Debug|x64.ActiveCfg = Debug|x64
+		{53A38611-6486-4FF5-8637-1C6BC38A6A18}.Debug|x64.Build.0 = Debug|x64
+		{53A38611-6486-4FF5-8637-1C6BC38A6A18}.Release|x64.ActiveCfg = Release|x64
+		{53A38611-6486-4FF5-8637-1C6BC38A6A18}.Release|x64.Build.0 = Release|x64
+		{C217E7C3-4A14-457E-ABC8-180546369646}.Debug|x64.ActiveCfg = Debug|x64
+		{C217E7C3-4A14-457E-ABC8-180546369646}.Debug|x64.Build.0 = Debug|x64
+		{C217E7C3-4A14-457E-ABC8-180546369646}.Release|x64.ActiveCfg = Release|x64
+		{C217E7C3-4A14-457E-ABC8-180546369646}.Release|x64.Build.0 = Release|x64
+		{562A58FF-DD9A-4839-B503-4520D3BE96DA}.Debug|x64.ActiveCfg = Debug|x64
+		{562A58FF-DD9A-4839-B503-4520D3BE96DA}.Debug|x64.Build.0 = Debug|x64
+		{562A58FF-DD9A-4839-B503-4520D3BE96DA}.Release|x64.ActiveCfg = Release|x64
+		{562A58FF-DD9A-4839-B503-4520D3BE96DA}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/MSFSTouchPortalPlugin/MSFSTouchPortalPlugin.csproj
+++ b/MSFSTouchPortalPlugin/MSFSTouchPortalPlugin.csproj
@@ -8,10 +8,16 @@
     <AssemblyVersion>1.0.0.0</AssemblyVersion>
     <FileVersion>1.0.0.0</FileVersion>
     <CodeAnalysisRuleSet>..\.sonarlint\msfstouchportalplugincsharp.ruleset</CodeAnalysisRuleSet>
+    <Platforms>x64</Platforms>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <PlatformTarget>x64</PlatformTarget>
+    <NoWarn>1701;1702;S125;CS8032</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>
@@ -49,7 +55,7 @@
 
   <ItemGroup>
     <Reference Include="Microsoft.FlightSimulator.SimConnect">
-      <HintPath>..\..\..\..\MSFS SDK\SimConnect SDK\lib\managed\Microsoft.FlightSimulator.SimConnect.dll</HintPath>
+      <HintPath>$(MSFS_SDK)\SimConnect SDK\lib\managed\Microsoft.FlightSimulator.SimConnect.dll</HintPath>
       <EmbedInteropTypes>false</EmbedInteropTypes>
       <Private>true</Private>
     </Reference>

--- a/MSFSTouchPortalPlugin/Properties/PublishProfiles/win-x64-Self.pubxml
+++ b/MSFSTouchPortalPlugin/Properties/PublishProfiles/win-x64-Self.pubxml
@@ -6,7 +6,7 @@ https://go.microsoft.com/fwlink/?LinkID=208121.
   <PropertyGroup>
     <PublishProtocol>FileSystem</PublishProtocol>
     <Configuration>Release</Configuration>
-    <Platform>Any CPU</Platform>
+    <Platform>x64</Platform>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <PublishDir>..\dist\win-x64</PublishDir>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>

--- a/TouchPortalExtension/TouchPortalExtension.csproj
+++ b/TouchPortalExtension/TouchPortalExtension.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <CodeAnalysisRuleSet>..\.sonarlint\msfstouchportalplugincsharp.ruleset</CodeAnalysisRuleSet>
+    <Platforms>x64</Platforms>
+    <Version>1.1.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/publish.ps1
+++ b/publish.ps1
@@ -21,7 +21,7 @@ dotnet restore "MSFSTouchPortalPlugin"
 dotnet restore "MSFSTouchPortalPlugin.Tests"
 
 Write-Information "Building 'MSFSTouchPortalPlugin' component...`n" -InformationAction Continue
-dotnet build "MSFSTouchPortalPlugin" --configuration $Configuration
+dotnet build "MSFSTouchPortalPlugin" --configuration $Configuration -p:Platform=x64
 
 Write-Information "Cleaning 'MSFSTouchPortalPlugin' packages-dist folder..." -InformationAction Continue
 $CurrentDir = [System.IO.Path]::GetDirectoryName($myInvocation.MyCommand.Path)
@@ -31,10 +31,10 @@ if (Test-Path $DistFolderPath) {
 }
 
 Write-Information "Publishing 'MSFSTouchPortalPlugin' component...`n" -InformationAction Continue
-dotnet publish "MSFSTouchPortalPlugin" --output "$DistFolderPath\MSFS-TouchPortal-Plugin\dist" --configuration $Configuration $VersionSuffixCommand $VersionSuffix -r "win-x64" --self-contained true
+dotnet publish "MSFSTouchPortalPlugin" --output "$DistFolderPath\MSFS-TouchPortal-Plugin\dist" --configuration $Configuration -p:Platform=x64 $VersionSuffixCommand $VersionSuffix -r "win-x64" --self-contained true
 
 # Run Documentation
-dotnet run -p "MSFSTouchPortalPlugin-Generator" ".\packages-dist\MSFS-TouchPortal-Plugin"
+dotnet run -p "MSFSTouchPortalPlugin-Generator" "$DistFolderPath\MSFS-TouchPortal-Plugin"
 
 # Copy Entry.tp, Readme, Documentation, CHANGELOG to publish
 copy "README.md" "$DistFolderPath\MSFS-TouchPortal-Plugin"
@@ -42,7 +42,7 @@ copy "CHANGELOG.md" "$DistFolderPath\MSFS-TouchPortal-Plugin"
 copy "airplane_takeoff24.png" "$DistFolderPath\MSFS-TouchPortal-Plugin"
 
 # Get version
-$FileVersion = (Get-Command packages-dist\MSFS-TouchPortal-Plugin\dist\MSFSTouchPortalPlugin.dll).FileVersionInfo.FileVersion
+$FileVersion = (Get-Command $DistFolderPath\MSFS-TouchPortal-Plugin\dist\MSFSTouchPortalPlugin.dll).FileVersionInfo.FileVersion
 
 # Create TPP File
 #Compress-Archive -Path "$DistFolderPath\MSFS-TouchPortal-Plugin" -DestinationPath "$DistFolderPath\MSFS-TouchPortal-Plugin.zip"


### PR DESCRIPTION
So VS was complaining that SimConnect was 64 bit and AllCPU was wrong...  VS complains a lot.  But it's not wrong.  And this way if we ever have a 32b version for FSX or whatever, it'll make more sense.

This assumes you have a `MSFS_SDK` environment variable defined with the location of the SimConnect SDK.  My system had it after I installed the SDK via MSFS developer mode.  YMMV...

