### PR TITLE
Add ability to pass event action data to SimConnect

### DIFF
--- a/MSFSTouchPortalPlugin-Generator/GenerateDoc.cs
+++ b/MSFSTouchPortalPlugin-Generator/GenerateDoc.cs
@@ -147,7 +147,7 @@ namespace MSFSTouchPortalPlugin_Generator {
       return model;
     }
 
-    private string CreateMarkdown(DocBase model) {
+    private static string CreateMarkdown(DocBase model) {
       var s = new StringBuilder();
 
       s.Append($"# {model.Title}\n\n");
@@ -170,8 +170,8 @@ namespace MSFSTouchPortalPlugin_Generator {
         s.Append("| --- | --- | --- | --- | --- | --- |\n");
         s.Append($"| {setting.ReadOnly} | {setting.Type} | {setting.DefaultValue} ");
         s.Append($"| {(setting.MaxLength > 0 ? setting.MaxLength : "N/A")} ");
-        s.Append($"| {(setting.MinValue != double.NaN ? setting.MinValue : "N/A")} ");
-        s.Append($"| {(setting.MaxValue != double.NaN ? setting.MaxValue : "N/A")} ");
+        s.Append($"| {(double.IsNaN(setting.MinValue) ? "N/A" : setting.MinValue)} ");
+        s.Append($"| {(double.IsNaN(setting.MaxValue) ? "N/A" : setting.MaxValue)} ");
         s.Append("|\n\n");
         s.Append(setting.Description + "\n\n");
       });

--- a/MSFSTouchPortalPlugin-Generator/GenerateEntry.cs
+++ b/MSFSTouchPortalPlugin-Generator/GenerateEntry.cs
@@ -52,7 +52,7 @@ namespace MSFSTouchPortalPlugin_Generator {
       // Add Plug Start Comand
       model.Plugin_start_cmd = Path.Combine("%TP_PLUGIN_FOLDER%", "MSFS-TouchPortal-Plugin\\dist", "MSFSTouchPortalPlugin.exe");
       // Load asembly
-      _ = MSFSTouchPortalPlugin.Objects.AutoPilot.AutoPilot.AP_AIRSPEED_HOLD;
+      _ = MSFSTouchPortalPlugin.Objects.Plugin.Plugin.Init;
 
       var q = assembly.GetTypes().ToList();
 
@@ -89,17 +89,20 @@ namespace MSFSTouchPortalPlugin_Generator {
             HasHoldFunctionality = actionAttribute.HasHoldFunctionality,
           };
 
-          // Has Choices
-          var choiceAttributes = act.GetCustomAttributes<TouchPortalActionChoiceAttribute>()?.ToList();
-
-          if (choiceAttributes?.Count > 0) {
-            for (int i = 0; i < choiceAttributes.Count; i++) {
+          // Action Data
+          var dataAttributes = act.GetCustomAttributes<TouchPortalActionDataAttribute>();
+          if (dataAttributes.Any()) {
+            for (int i = 0, e = dataAttributes.Count(); i < e; ++i) {
+              var attrib = dataAttributes.ElementAt(i);
               var data = new TouchPortalActionData {
                 Id = $"{action.Id}.Data.{i}",
-                Type = "choice",
-                Label = "Action",
-                DefaultValue = choiceAttributes[i].DefaultValue,
-                ValueChoices = choiceAttributes[i].ChoiceValues
+                Type = attrib.Type,
+                Label = attrib.Label ?? "Action",
+                DefaultValue = attrib.GetDefaultValue(),
+                ValueChoices = attrib.ChoiceValues,
+                MinValue = attrib.MinValue,
+                MaxValue = attrib.MaxValue,
+                AllowDecimals = attrib.AllowDecimals,
               };
 
               action.Data.Add(data);

--- a/MSFSTouchPortalPlugin-Generator/GenerateEntry.cs
+++ b/MSFSTouchPortalPlugin-Generator/GenerateEntry.cs
@@ -162,9 +162,9 @@ namespace MSFSTouchPortalPlugin_Generator {
           };
           if (att.MaxLength > 0)
             setting.MaxLength = att.MaxLength;
-          if (att.MinValue != double.NaN)
+          if (!double.IsNaN(att.MinValue))
             setting.MinValue = att.MinValue;
-          if (att.MaxValue != double.NaN)
+          if (!double.IsNaN(att.MaxValue))
             setting.MaxValue = att.MaxValue;
 
           model.Settings.Add(setting);

--- a/MSFSTouchPortalPlugin-Generator/MSFSTouchPortalPlugin-Generator.csproj
+++ b/MSFSTouchPortalPlugin-Generator/MSFSTouchPortalPlugin-Generator.csproj
@@ -18,6 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
   </ItemGroup>
 

--- a/MSFSTouchPortalPlugin-Generator/Model/Base.cs
+++ b/MSFSTouchPortalPlugin-Generator/Model/Base.cs
@@ -25,7 +25,7 @@ namespace MSFSTouchPortalPlugin_Generator.Model {
     [Required, RegularExpression(@"^#[A-Fa-f0-9]{6}$")]
     public string ColorDark { get; set; } = "#000000";
     [Required, RegularExpression(@"^#[A-Fa-f0-9]{6}$")]
-    public string ColorLight { get; set; } = "#23CF5F";
+    public string ColorLight { get; set; } = "#00B4FF";
   }
 
   class TouchPortalCategory {

--- a/MSFSTouchPortalPlugin-Generator/Model/Base.cs
+++ b/MSFSTouchPortalPlugin-Generator/Model/Base.cs
@@ -65,9 +65,18 @@ namespace MSFSTouchPortalPlugin_Generator.Model {
     [Required]
     public string Label { get; set; } = "Action";
     [Required, JsonProperty("default")]
-    public string DefaultValue { get; set; }
-    [Required]
+    public object DefaultValue { get; set; } = null;
+    [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
     public string[] ValueChoices { get; set; }
+    [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+    [DefaultValue(double.NaN)]
+    public double MinValue { get; set; } = double.NaN;
+    [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+    [DefaultValue(double.NaN)]
+    public double MaxValue { get; set; } = double.NaN;
+    [JsonProperty(DefaultValueHandling = DefaultValueHandling.Ignore)]
+    [DefaultValue(true)]
+    public bool AllowDecimals { get; set; } = true;
   }
 
   class TouchPortalState {

--- a/MSFSTouchPortalPlugin-Generator/Model/DocBase.cs
+++ b/MSFSTouchPortalPlugin-Generator/Model/DocBase.cs
@@ -40,6 +40,9 @@ namespace MSFSTouchPortalPlugin_Generator.Model {
     public string Type { get; set; }
     public string Values { get; set; }
     public string DefaultValue { get; set; }
+    public double MinValue { get; set; }
+    public double MaxValue { get; set; }
+    public bool AllowDecimals { get; set; }
   }
 
   public class DocState {

--- a/MSFSTouchPortalPlugin-Generator/Model/DocBase.cs
+++ b/MSFSTouchPortalPlugin-Generator/Model/DocBase.cs
@@ -22,9 +22,9 @@ namespace MSFSTouchPortalPlugin_Generator.Model {
 
   public class DocCategory {
     public string Name { get; set; }
-    public List<DocAction> Actions { get; set; } = new List<DocAction>();
-    public List<DocState> States { get; set; } = new List<DocState>();
-    public List<object> Events { get; set; } = new List<object>();
+    public List<DocAction> Actions { get; set; } = new();
+    public List<DocState> States { get; set; } = new();
+    public List<object> Events { get; set; } = new();
   }
 
   public class DocAction {
@@ -33,7 +33,8 @@ namespace MSFSTouchPortalPlugin_Generator.Model {
     public string Type { get; set; }
     public string Format { get; set; }
     public bool HasHoldFunctionality { get; set; } = false;
-    public List<DocActionData> Data { get; set; } = new List<DocActionData>();
+    public List<DocActionData> Data { get; set; } = new();
+    public List<DocActionMapping> Mappings { get; set; } = new();
   }
 
   public class DocActionData {
@@ -45,10 +46,17 @@ namespace MSFSTouchPortalPlugin_Generator.Model {
     public bool AllowDecimals { get; set; }
   }
 
+  public class DocActionMapping
+  {
+    public string ActionId { get; set; }
+    public string[] Values { get; set; }
+  }
+
   public class DocState {
     public string Id { get; set; }
     public string Type { get; set; }
     public string Description { get; set; }
     public string DefaultValue { get; set; }
+    public string SimVarName { get; set; }
   }
 }

--- a/MSFSTouchPortalPlugin/Attributes/SimActionEventAttribute.cs
+++ b/MSFSTouchPortalPlugin/Attributes/SimActionEventAttribute.cs
@@ -1,7 +1,0 @@
-﻿using System;
-
-namespace MSFSTouchPortalPlugin.Attributes {
-  [AttributeUsage(AttributeTargets.Field)]
-  internal class SimActionEventAttribute : Attribute {
-  }
-}

--- a/MSFSTouchPortalPlugin/Attributes/SimNotificationGroupAttribute.cs
+++ b/MSFSTouchPortalPlugin/Attributes/SimNotificationGroupAttribute.cs
@@ -2,7 +2,7 @@
 using System;
 
 namespace MSFSTouchPortalPlugin.Attributes {
-  [AttributeUsage(AttributeTargets.Enum)]
+  [AttributeUsage(AttributeTargets.Enum | AttributeTargets.Class)]
   internal class SimNotificationGroupAttribute : Attribute {
     public Groups Group;
 

--- a/MSFSTouchPortalPlugin/Attributes/TouchPortalActionMappingAttribute.cs
+++ b/MSFSTouchPortalPlugin/Attributes/TouchPortalActionMappingAttribute.cs
@@ -1,18 +1,21 @@
 ﻿using System;
 
-namespace MSFSTouchPortalPlugin.Attributes {
+namespace MSFSTouchPortalPlugin.Attributes
+{
+  [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property, AllowMultiple = true)]
   internal class TouchPortalActionMappingAttribute : Attribute {
     public string ActionId;
     public string[] Values;
 
-    public TouchPortalActionMappingAttribute(string actionId, string value) {
-      ActionId = actionId;
-      Values = new [] { value };
-    }
-
+    public TouchPortalActionMappingAttribute(string actionId, string value) :
+      this(actionId, new [] { value }) { }
+    public TouchPortalActionMappingAttribute(string actionId, string value1, string value2) :
+      this(actionId, new[] { value1, value2 }) { }
+    public TouchPortalActionMappingAttribute(string actionId, string value1, string value2, string value3) :
+      this(actionId, new[] { value1, value2, value3 }) { }
     public TouchPortalActionMappingAttribute(string actionId, string[] values = null) {
       ActionId = actionId;
-      Values = values ?? new string [] { };
+      Values = values ?? Array.Empty<string>();
     }
   }
 }

--- a/MSFSTouchPortalPlugin/Interfaces/IReflectionService.cs
+++ b/MSFSTouchPortalPlugin/Interfaces/IReflectionService.cs
@@ -3,11 +3,15 @@ using MSFSTouchPortalPlugin.Types;
 using System;
 using System.Collections.Generic;
 
-namespace MSFSTouchPortalPlugin.Interfaces {
+namespace MSFSTouchPortalPlugin.Interfaces
+{
   internal interface IReflectionService {
-    Dictionary<string, Enum> GetInternalEvents();
-    Dictionary<string, Enum> GetActionEvents();
+    Dictionary<string, ActionEventType> GetActionEvents();
     Dictionary<Definition, SimVarItem> GetStates();
     Dictionary<string, PluginSetting> GetSettings();
+    ref readonly Dictionary<Enum, dynamic> GetClientEventIdToNameMap();
+    string GetSimEventNameById(Enum id);
+    string GetSimEventNameById(uint id);
+    string GetSimEventNameById(int id);
   }
 }

--- a/MSFSTouchPortalPlugin/Interfaces/IReflectionService.cs
+++ b/MSFSTouchPortalPlugin/Interfaces/IReflectionService.cs
@@ -1,4 +1,5 @@
 ﻿using MSFSTouchPortalPlugin.Constants;
+using MSFSTouchPortalPlugin.Types;
 using System;
 using System.Collections.Generic;
 
@@ -7,6 +8,6 @@ namespace MSFSTouchPortalPlugin.Interfaces {
     Dictionary<string, Enum> GetInternalEvents();
     Dictionary<string, Enum> GetActionEvents();
     Dictionary<Definition, SimVarItem> GetStates();
-    Dictionary<string, Objects.Plugin.PluginSetting> GetSettings();
+    Dictionary<string, PluginSetting> GetSettings();
   }
 }

--- a/MSFSTouchPortalPlugin/MSFSTouchPortalPlugin.csproj
+++ b/MSFSTouchPortalPlugin/MSFSTouchPortalPlugin.csproj
@@ -32,8 +32,9 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="6.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="6.0.1" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="6.0.0" />
     <PackageReference Include="Serilog.Extensions.Logging" Version="3.1.0" />
     <PackageReference Include="Serilog.Settings.Configuration" Version="3.3.0" />

--- a/MSFSTouchPortalPlugin/Objects/AutoPilot/AutoPilot.cs
+++ b/MSFSTouchPortalPlugin/Objects/AutoPilot/AutoPilot.cs
@@ -3,9 +3,10 @@ using MSFSTouchPortalPlugin.Constants;
 using MSFSTouchPortalPlugin.Enums;
 using TouchPortalExtension.Attributes;
 
-namespace MSFSTouchPortalPlugin.Objects.AutoPilot {
-
+namespace MSFSTouchPortalPlugin.Objects.AutoPilot
+{
   [SimVarDataRequestGroup]
+  [SimNotificationGroup(Groups.AutoPilot)]
   [TouchPortalCategory("AutoPilot", "MSFS - AutoPilot")]
   internal static class AutoPilotMapping {
 
@@ -13,7 +14,10 @@ namespace MSFSTouchPortalPlugin.Objects.AutoPilot {
 
     [SimVarDataRequest]
     [TouchPortalAction("AutoPilotMaster", "AutoPilot", "MSFS", "Toggle/On/Off Auto Pilot", "Auto Pilot Master - {0}")]
-    [TouchPortalActionChoice(new [] { "Toggle", "On", "Off" }, "Toggle")]
+    [TouchPortalActionChoice(new [] { "Toggle", "On", "Off" })]
+    [TouchPortalActionMapping("AP_MASTER", "Toggle")]
+    [TouchPortalActionMapping("AUTOPILOT_ON", "On")]
+    [TouchPortalActionMapping("AUTOPILOT_OFF", "Off")]
     [TouchPortalState("AutoPilotMaster", "text", "AutoPilot Master Status", "")]
     public static readonly SimVarItem AP_MASTER = new SimVarItem { Def = Definition.AutoPilotMaster, SimVarName = "AUTOPILOT MASTER", Unit = Units.Bool, CanSet = false };
 
@@ -33,14 +37,20 @@ namespace MSFSTouchPortalPlugin.Objects.AutoPilot {
 
     [SimVarDataRequest]
     [TouchPortalAction("AutoPilotAttitude", "Attitude Hold", "MSFS", "Toggle/On/Off the attitude hold for auto pilot", "Attitude Hold - {0}")]
-    [TouchPortalActionChoice(new [] { "Toggle", "On", "Off" }, "Toggle")]
+    [TouchPortalActionChoice(new [] { "Toggle", "On", "Off" })]
+    [TouchPortalActionMapping("AP_ATT_HOLD", "Toggle")]
+    [TouchPortalActionMapping("AP_ATT_HOLD_ON", "On")]
+    [TouchPortalActionMapping("AP_ATT_HOLD_OFF", "Off")]
     [TouchPortalState("AutoPilotAttitudeHold", "text", "AutoPilot Attitude Status", "")]
     public static readonly SimVarItem AP_ATTITUDE =
       new SimVarItem { Def = Definition.AutoPilotAttitudeHold, SimVarName = "AUTOPILOT ATTITUDE HOLD", Unit = Units.Bool, CanSet = false };
 
     [SimVarDataRequest]
     [TouchPortalAction("AutoPilotAttitudeVar", "Attitude Hold Value", "MSFS", "Sets the attitude hold value", "Attitude Hold Value - {0}", true)]
-    [TouchPortalActionChoice(new [] { "Select", "Increase", "Decrease" }, "Select")]
+    [TouchPortalActionChoice(new [] { "Select", "Increase", "Decrease" })]
+    [TouchPortalActionMapping("AP_PITCH_REF_INC_UP", "Increase")]
+    [TouchPortalActionMapping("AP_PITCH_REF_INC_DN", "Decrease")]
+    [TouchPortalActionMapping("AP_PITCH_REF_SELECT", "Set")]
     [TouchPortalState("AutoPilotAttitudeVar", "text", "AutoPilot Pitch Reference Value", "")]
     public static readonly SimVarItem AP_ATTITUDE_PITCH =
       new SimVarItem { Def = Definition.AutoPilotAttitudeVar, SimVarName = "AUTOPILOT PITCH HOLD REF", Unit = Units.radians, CanSet = false };
@@ -51,7 +61,10 @@ namespace MSFSTouchPortalPlugin.Objects.AutoPilot {
 
     [SimVarDataRequest]
     [TouchPortalAction("AutoPilotApproach", "Approach Mode", "MSFS", "Toggle/On/Off the approach mode for auto pilot", "Approach Mode - {0}")]
-    [TouchPortalActionChoice(new [] { "Toggle", "On", "Off" }, "Toggle")]
+    [TouchPortalActionChoice(new [] { "Toggle", "On", "Off" })]
+    [TouchPortalActionMapping("AP_APR_HOLD", "Toggle")]
+    [TouchPortalActionMapping("AP_APR_HOLD_ON", "On")]
+    [TouchPortalActionMapping("AP_APR_HOLD_OFF", "Off")]
     [TouchPortalState("AutoPilotApproachHold", "text", "AutoPilot Approach Status", "")]
     public static readonly SimVarItem AP_APPROACH =
       new SimVarItem { Def = Definition.AutoPilotApproachHold, SimVarName = "AUTOPILOT APPROACH HOLD", Unit = Units.Bool, CanSet = false };
@@ -62,7 +75,9 @@ namespace MSFSTouchPortalPlugin.Objects.AutoPilot {
 
     [SimVarDataRequest]
     [TouchPortalAction("AutoPilotBanking", "AP Max Bank Angle", "MSFS", "Increase/Decrease the max bank angle", "Max Bank Angle - {0}", true)]
-    [TouchPortalActionChoice(new [] { "Increase", "Decrease" }, "Increase")]
+    [TouchPortalActionChoice(new [] { "Increase", "Decrease" })]
+    [TouchPortalActionMapping("AP_MAX_BANK_INC", "Increase")]
+    [TouchPortalActionMapping("AP_MAX_BANK_DEC", "Decrease")]
     [TouchPortalState("AutoPilotBanking", "text", "AutoPilot Max Bank Angle", "")]
     public static readonly SimVarItem AP_MAX_BANK =
       new SimVarItem { Def = Definition.AutoPilotBanking, SimVarName = "AUTOPILOT MAX BANK", Unit = Units.radians, CanSet = false };
@@ -73,18 +88,28 @@ namespace MSFSTouchPortalPlugin.Objects.AutoPilot {
 
     [SimVarDataRequest]
     [TouchPortalAction("AutoPilotHeading", "Heading Hold", "MSFS", "Toggle/On/Off the heading hold for auto pilot", "Heading Hold - {0}")]
-    [TouchPortalActionChoice(new [] { "Toggle", "On", "Off" }, "Toggle")]
+    [TouchPortalActionChoice(new [] { "Toggle", "On", "Off" })]
+    [TouchPortalActionMapping("AP_HDG_HOLD",     "Toggle")]
+    [TouchPortalActionMapping("AP_HDG_HOLD_ON",  "On")]
+    [TouchPortalActionMapping("AP_HDG_HOLD_OFF", "Off")]
     [TouchPortalState("AutoPilotHeadingHold", "text", "AutoPilot Heading Status", "")]
     public static readonly SimVarItem AP_HEADING =
       new SimVarItem { Def = Definition.AutoPilotHeadingHold, SimVarName = "AUTOPILOT HEADING LOCK", Unit = Units.Bool, CanSet = false };
 
-
     [SimVarDataRequest]
-    [TouchPortalAction("AutoPilotHeadingVar", "Heading Hold Value", "MSFS", "Sets the heading hold value", "Heading Hold Value - {0}", true)]
-    [TouchPortalActionChoice(new [] { "Select", "Increase", "Decrease", "Set" }, "Select")]
+    [TouchPortalAction("AutoPilotHeadingVar", "Heading Hold Value Adj/Sel", "MSFS", "Adjusts the heading hold value", "Heading Hold Value - {0}", true)]
+    [TouchPortalActionChoice(new [] { "Select", "Increase", "Decrease" })]
+    [TouchPortalActionMapping("HEADING_BUG_INC",    "Increase")]
+    [TouchPortalActionMapping("HEADING_BUG_DEC",    "Decrease")]
+    [TouchPortalActionMapping("HEADING_BUG_SELECT", "Select")]
     [TouchPortalState("AutoPilotHeadingVar", "text", "AutoPilot Heading Direction", "")]
     public static readonly SimVarItem AP_HEADING_VAR =
       new SimVarItem { Def = Definition.AutoPilotHeadingVar, SimVarName = "AUTOPILOT HEADING LOCK DIR", Unit = Units.degrees, CanSet = false, StringFormat = "{0:F0}" };
+
+    [TouchPortalAction("AutoPilotHeadingSet", "Heading Hold Value Set", "MSFS", "Sets the heading hold value", "Heading Hold Value - {0}")]
+    [TouchPortalActionText("1", 0, 359)]
+    [TouchPortalActionMapping("HEADING_BUG_SET")]
+    public static object AP_HEADING_SET { get; }
 
     #endregion
 
@@ -92,18 +117,31 @@ namespace MSFSTouchPortalPlugin.Objects.AutoPilot {
 
     [SimVarDataRequest]
     [TouchPortalAction("AutoPilotAltitude", "Altitude Hold", "MSFS", "Toggle/On/Off the altitude hold for auto pilot", "Altitude Hold - {0}")]
-    [TouchPortalActionChoice(new [] { "Toggle", "On", "Off" }, "Toggle")]
+    [TouchPortalActionChoice(new [] { "Toggle", "On", "Off" })]
+    [TouchPortalActionMapping("AP_ALT_HOLD", "Toggle")]
+    [TouchPortalActionMapping("AP_ALT_HOLD_ON", "On")]
+    [TouchPortalActionMapping("AP_ALT_HOLD_OFF", "Off")]
     [TouchPortalState("AutoPilotAltitudeHold", "text", "AutoPilot Altitude Status", "")]
     public static readonly SimVarItem AP_ALTITUDE =
       new SimVarItem { Def = Definition.AutoPilotAltitudeHold, SimVarName = "AUTOPILOT ALTITUDE LOCK", Unit = Units.Bool, CanSet = false };
 
 
     [SimVarDataRequest]
-    [TouchPortalAction("AutoPilotAltitudeVar", "Altitude Hold Value", "MSFS", "Sets the altitude hold value", "Altitude Hold Value - {0}", true)]
-    [TouchPortalActionChoice(new [] { "Select", "Increase", "Decrease", "Set", "Set Metric" }, "Select")]
+    [TouchPortalAction("AutoPilotAltitudeVar", "Altitude Hold Value Adj/Sel", "MSFS", "Adjusts or selects the altitude hold value", "Altitude Hold Value - {0}", true)]
+    [TouchPortalActionChoice(new [] { "Select", "Increase", "Decrease" })]
+    [TouchPortalActionMapping("AP_ALT_VAR_INC", "Increase")]
+    [TouchPortalActionMapping("AP_ALT_VAR_DEC", "Decrease")]
+    [TouchPortalActionMapping("ALTITUDE_BUG_SELECT", "Select")]
     [TouchPortalState("AutoPilotAltitudeVar", "text", "AutoPilot Altitude Value", "")]
     public static readonly SimVarItem AP_ALTITUDE_VAR =
       new SimVarItem { Def = Definition.AutoPilotAltitudeVar, SimVarName = "AUTOPILOT ALTITUDE LOCK VAR", Unit = Units.feet, CanSet = false };
+
+    [TouchPortalAction("AutoPilotAltitudeSet", "Altitude Hold Value Set", "MSFS", "Sets the altitude hold value", "Altitude Hold Value - {0} to {1}")]
+    [TouchPortalActionChoice(new[] { "Set English", "Set Metric" })]
+    [TouchPortalActionText("0")]
+    [TouchPortalActionMapping("AP_ALT_VAR_SET_ENGLISH", "Set English")]
+    [TouchPortalActionMapping("AP_ALT_VAR_SET_METRIC", "Set Metric")]
+    public static object AP_ALTITUDE_SET { get; }
 
     #endregion
 
@@ -111,7 +149,10 @@ namespace MSFSTouchPortalPlugin.Objects.AutoPilot {
 
     [SimVarDataRequest]
     [TouchPortalAction("AutoPilotBackCourse", "Back Course Mode", "MSFS", "Toggle/On/Off the back course mode for auto pilot", "Back Course Mode - {0}")]
-    [TouchPortalActionChoice(new [] { "Toggle", "On", "Off" }, "Toggle")]
+    [TouchPortalActionChoice(new [] { "Toggle", "On", "Off" })]
+    [TouchPortalActionMapping("AP_BC_HOLD", "Toggle")]
+    [TouchPortalActionMapping("AP_BC_HOLD_ON", "On")]
+    [TouchPortalActionMapping("AP_BC_HOLD_OFF", "Off")]
     [TouchPortalState("AutoPilotBackCourseHold", "text", "AutoPilot Back Course Status", "")]
     public static readonly SimVarItem AP_BACKCOURSE =
       new SimVarItem { Def = Definition.AutoPilotBackCourseHold, SimVarName = "AUTOPILOT BACKCOURSE HOLD", Unit = Units.Bool, CanSet = false };
@@ -122,14 +163,18 @@ namespace MSFSTouchPortalPlugin.Objects.AutoPilot {
 
     [SimVarDataRequest]
     [TouchPortalAction("AutoPilotNav1", "Nav1 Mode", "MSFS", "Toggle/On/Off the Nav1 mode for auto pilot", "Nav1 Mode - {0}")]
-    [TouchPortalActionChoice(new [] { "Toggle", "On", "Off" }, "Toggle")]
+    [TouchPortalActionChoice(new [] { "Toggle", "On", "Off" })]
+    [TouchPortalActionMapping("AP_NAV1_HOLD", "Toggle")]
+    [TouchPortalActionMapping("AP_NAV1_HOLD_ON", "On")]
+    [TouchPortalActionMapping("AP_NAV1_HOLD_OFF", "Off")]
     [TouchPortalState("AutoPilotNav1Hold", "text", "AutoPilot Nav1 Status", "")]
     public static readonly SimVarItem AP_NAV1 =
       new SimVarItem { Def = Definition.AutoPilotNav1Hold, SimVarName = "AUTOPILOT NAV1 LOCK", Unit = Units.Bool, CanSet = false };
 
     [SimVarDataRequest]
     [TouchPortalAction("AutoPilotNavSelect", "Nav Mode - Set", "MSFS", "Sets the nav to 1 or 2 for Nav mode", "Nav Mode - {0} ")]
-    [TouchPortalActionChoice(new [] { "1", "2" }, "1")]
+    [TouchPortalActionNumeric(1, 1, 2)]
+    [TouchPortalActionMapping("AP_NAV_SELECT_SET")]
     [TouchPortalState("AutoPilotNavSelected", "text", "AutoPilot Nav Selected Index", "")]
     public static readonly SimVarItem AP_NAV_SELECT_SET =
       new SimVarItem { Def = Definition.AutoPilotNavSelected, SimVarName = "AUTOPILOT NAV SELECTED", Unit = Units.number, CanSet = false };
@@ -140,36 +185,61 @@ namespace MSFSTouchPortalPlugin.Objects.AutoPilot {
 
     [SimVarDataRequest]
     [TouchPortalAction("AutoPilotVerticalSpeed", "Vertical Speed", "MSFS", "Toggle the Vertical Speed for auto pilot", "Vertical Speed - {0}")]
-    [TouchPortalActionChoice(new [] { "Toggle" }, "Toggle")]
+    [TouchPortalActionChoice(new [] { "Toggle", "On", "Off" })]
+    [TouchPortalActionMapping("AP_VS_HOLD", "Toggle")]
+    [TouchPortalActionMapping("AP_VS_ON", "On")]
+    [TouchPortalActionMapping("AP_VS_OFF", "Off")]
     [TouchPortalState("AutoPilotVerticalSpeedHold", "text", "AutoPilot Vertical Speed Status", "")]
-    public static readonly SimVarItem AutoPilotVerticalSpeedHold = 
+    public static readonly SimVarItem AutoPilotVerticalSpeedHold =
       new SimVarItem { Def = Definition.AutoPilotVerticalSpeedHold, SimVarName = "AUTOPILOT VERTICAL HOLD", Unit = Units.Bool, CanSet = false };
 
-
     [SimVarDataRequest]
-    [TouchPortalAction("AutoPilotVerticalSpeedVar", "Vertical Speed Value", "MSFS", "Sets the vertical speed value", "Vertical Speed Value - {0}", true)]
-    [TouchPortalActionChoice(new [] { "Select", "Increase", "Decrease", "Set", "Set Metric" }, "Select")]
+    [TouchPortalAction("AutoPilotVerticalSpeedVar", "Vertical Speed Value", "MSFS", "Adjusts or selects the vertical speed value", "Vertical Speed Value - {0}", true)]
+    [TouchPortalActionChoice(new [] { "Select", "Increase", "Decrease", "Set Current" })]
+    [TouchPortalActionMapping("VSI_BUG_SELECT", "Select")]
+    [TouchPortalActionMapping("AP_VS_VAR_INC", "Increase")]
+    [TouchPortalActionMapping("AP_VS_VAR_DEC", "Decrease")]
+    [TouchPortalActionMapping("AP_VS_VAR_SET_CURRENT", "Set Current")]
     [TouchPortalState("AutoPilotVerticalSpeedVar", "text", "AutoPilot Vertical Speed Value", "")]
     public static readonly SimVarItem AP_VERTICALSPEED_VAR =
       new SimVarItem { Def = Definition.AutoPilotVerticalSpeedVar, SimVarName = "AUTOPILOT VERTICAL HOLD VAR", Unit = Units.feetminute, CanSet = false };
+
+    [TouchPortalAction("AutoPilotVerticalSpeedSet", "Vertical Speed Value Set", "MSFS", "Sets the vertical speed value", "Vertical Speed Hold Value - {0} to {1}")]
+    [TouchPortalActionChoice(new[] { "Set English", "Set Metric" })]
+    [TouchPortalActionText("1", -5000, 5000)]
+    [TouchPortalActionMapping("AP_VS_VAR_SET_ENGLISH", "Set English")]
+    [TouchPortalActionMapping("AP_VS_VAR_SET_METRIC", "Set Metric")]
+    public static object AP_VERTICALSPEED_SET { get; }
 
     #endregion
 
     #region Airspeed
 
     [SimVarDataRequest]
-    [TouchPortalAction("AutoPilotAirSpeed", "Airspeed Hold", "MSFS", "Toggle/On/Off/Set the airspeed hold for auto pilot", "Airspeed Hold - {0}")]
-    [TouchPortalActionChoice(new [] { "Toggle", "On", "Off", "Set" }, "Toggle")]
+    [TouchPortalAction("AutoPilotAirSpeed", "Airspeed Hold", "MSFS", "Toggle/On/Off the airspeed hold for auto pilot", "Airspeed Hold - {0}")]
+    [TouchPortalActionChoice(new [] { "Toggle", "On", "Off" })]
+    [TouchPortalActionMapping("AP_AIRSPEED_HOLD", "Toggle")]
+    [TouchPortalActionMapping("AP_AIRSPEED_ON", "On")]
+    [TouchPortalActionMapping("AP_AIRSPEED_OFF", "Off")]
     [TouchPortalState("AutoPilotAirSpeedHold", "text", "AutoPilot Air Speed Status", "")]
     public static readonly SimVarItem AP_AIRSPEED =
       new SimVarItem { Def = Definition.AutoPilotAirSpeedHold, SimVarName = "AUTOPILOT AIRSPEED HOLD", Unit = Units.Bool, CanSet = false };
 
     [SimVarDataRequest]
-    [TouchPortalAction("AutoPilotAirSpeedVar", "Airspeed Hold Value", "MSFS", "Sets the airspeed hold value", "Airspeed Hold Value - {0}", true)]
-    [TouchPortalActionChoice(new [] { "Select", "Increase", "Decrease", "Set" }, "Select")]
+    [TouchPortalAction("AutoPilotAirSpeedVar", "Airspeed Hold Value", "MSFS", "Adjusts the airspeed hold value", "Airspeed Hold Value - {0}", true)]
+    [TouchPortalActionChoice(new [] { "Select", "Increase", "Decrease", "Set" })]
+    [TouchPortalActionMapping("AIRSPEED_BUG_SELECT", "Select")]
+    [TouchPortalActionMapping("AP_SPD_VAR_INC", "Increase")]
+    [TouchPortalActionMapping("AP_SPD_VAR_DEC", "Decrease")]
+    [TouchPortalActionMapping("AP_SPD_VAR_SET", "Set")]
     [TouchPortalState("AutoPilotAirSpeedVar", "text", "AutoPilot Air Speed Value", "")]
     public static readonly SimVarItem AP_AIRSPEED_VAR =
       new SimVarItem { Def = Definition.AutoPilotAirSpeedVar, SimVarName = "AUTOPILOT AIRSPEED HOLD VAR", Unit = Units.knots, CanSet = false };
+
+    [TouchPortalAction("AutoPilotAirSpeedSet", "Airspeed Value Set", "MSFS", "Sets the airspeed value", "Set Airspeed Hold Value tp {0}")]
+    [TouchPortalActionText("1", 0, 5000)]
+    [TouchPortalActionMapping("AP_SPD_VAR_SET")]
+    public static object AP_AIRSPEED_SET { get; }
 
     #endregion
 
@@ -177,7 +247,9 @@ namespace MSFSTouchPortalPlugin.Objects.AutoPilot {
 
     [SimVarDataRequest]
     [TouchPortalAction("AutoThrottle", "Auto Throttle Mode", "MSFS", "Toggles the Arm/GoAround modes for auto throttle", "Toggle Auto Throttle - {0}")]
-    [TouchPortalActionChoice(new [] { "Arm", "GoAround" }, "Arm")]
+    [TouchPortalActionChoice(new [] { "Arm", "GoAround" })]
+    [TouchPortalActionMapping("AUTO_THROTTLE_ARM", "Arm")]
+    [TouchPortalActionMapping("AUTO_THROTTLE_TO_GA", "GoAround")]
     [TouchPortalState("AutoThrottleArm", "text", "Auto Throttle Armed", "")]
     public static readonly SimVarItem AUTO_THROTTLE =
       new SimVarItem { Def = Definition.AutoThrottleArm, SimVarName = "AUTOPILOT THROTTLE ARM", Unit = Units.Bool, CanSet = false };
@@ -193,7 +265,9 @@ namespace MSFSTouchPortalPlugin.Objects.AutoPilot {
     #region AutoBrake
 
     [TouchPortalAction("AutoBrake", "Auto Brake", "MSFS", "Increase/Decrease the auto brake", "Auto Brake - {0}", true)]
-    [TouchPortalActionChoice(new [] { "Increaes", "Decrease" }, "Increase")]
+    [TouchPortalActionChoice(new [] { "Increaes", "Decrease" })]
+    [TouchPortalActionMapping("INCREASE_AUTOBRAKE_CONTROL", "Increase")]
+    [TouchPortalActionMapping("DECREASE_AUTOBRAKE_CONTROL", "Decrease")]
     public static object AUTO_BRAKE { get; }
 
     #endregion
@@ -201,39 +275,50 @@ namespace MSFSTouchPortalPlugin.Objects.AutoPilot {
     #region Mach
 
     [SimVarDataRequest]
-    [TouchPortalAction("AutoPilotMach", "Mach Hold", "MSFS", "Toggle/On/Off/Set the mach hold for auto pilot", "Mach Hold - {0}")]
-    [TouchPortalActionChoice(new [] { "Toggle", "On", "Off", "Set" }, "Toggle")]
+    [TouchPortalAction("AutoPilotMach", "Mach Hold", "MSFS", "Toggle/On/Off the mach hold for auto pilot", "Mach Hold - {0}")]
+    [TouchPortalActionChoice(new [] { "Toggle", "On", "Off"})]
+    [TouchPortalActionMapping("AP_MACH_HOLD", "Toggle")]
+    [TouchPortalActionMapping("AP_MACH_ON", "On")]
+    [TouchPortalActionMapping("AP_MACH_OFF", "Off")]
     [TouchPortalState("AutoPilotMach", "text", "AutoPilot Mach Hold", "")]
     public static readonly SimVarItem AP_MACH =
       new SimVarItem { Def = Definition.AutoPilotMach, SimVarName = "AUTOPILOT MACH HOLD", Unit = Units.Bool, CanSet = false };
 
     [SimVarDataRequest]
     [TouchPortalAction("AutoPilotMachVar", "Mach Hold Value", "MSFS", "Sets the mach hold value", "Mach Hold Value - {0}")]
-    [TouchPortalActionChoice(new [] { "Select", "Increase", "Decrease" }, "Increase")]
+    [TouchPortalActionChoice(new [] { "Select", "Increase", "Decrease" })]
+    [TouchPortalActionMapping("AP_MACH_VAR_INC", "Increase")]
+    [TouchPortalActionMapping("AP_MACH_VAR_DEC", "Decrease")]
     [TouchPortalState("AutoPilotMachVar", "text", "AutoPilot Mach Value", "")]
     public static readonly SimVarItem AP_MACH_VAR =
       new SimVarItem { Def = Definition.AutoPilotMachVar, SimVarName = "AUTOPILOT MACH HOLD VAR", Unit = Units.number, CanSet = false };
+
+    [TouchPortalAction("AutoPilotMachSet", "Mach Hold Value Set", "MSFS", "Sets the mach hold value", "Set Mach Hold Value tp {0}")]
+    [TouchPortalActionText("0", 0, 20)]
+    [TouchPortalActionMapping("AP_MACH_VAR_SET")]
+    public static object AP_MACH_SET { get; }
 
     #endregion
 
     #region Flight Director
 
     [SimVarDataRequest]
-    [TouchPortalAction("AutoPilotFlightDirector", "Flight Director", "MSFS", "Toggle the Flight Director for auto pilot", "Flight Director - {0}")]
-    [TouchPortalActionChoice(new [] { "Toggle" }, "Toggle")]
+    [TouchPortalAction("AutoPilotFlightDirector", "Flight Director", "MSFS", "Toggle the Flight Director for auto pilot", "Toggle Flight Director On/Off")]
+    [TouchPortalActionMapping("TOGGLE_FLIGHT_DIRECTOR")]
     [TouchPortalState("AutoPilotFlightDirector", "text", "AutoPilot Flight Director Status", "")]
     public static readonly SimVarItem AP_FLIGHT_DIRECTOR =
       new SimVarItem { Def = Definition.AutoPilotFlightDirector, SimVarName = "AUTOPILOT FLIGHT DIRECTOR ACTIVE", Unit = Units.Bool, CanSet = false };
 
     [SimVarDataRequest]
     [TouchPortalAction("AutoPilotFlightDirectorCurrentPitch", "Flight Director Pitch Sync", "MSFS", "Syncs the Flight Director with the current pitch", "Flight Director Pitch Sync")]
+    [TouchPortalActionMapping("SYNC_FLIGHT_DIRECTOR_PITCH")]
     [TouchPortalState("AutoPilotFlightDirectorCurrentPitch", "text", "Flight Director Current Pitch", "")]
     public static readonly SimVarItem SYNC_FLIGHT_DIRECTOR_PITCH =
       new SimVarItem { Def = Definition.AutoPilotFlightDirectorCurrentPitch, SimVarName = "AUTOPILOT FLIGHT DIRECTOR PITCH", Unit = Units.radians, CanSet = false };
 
     [TouchPortalState("AutoPilotFlightDirectorCurrentBank", "text", "Flight Director Current Bank", "")]
     public static readonly SimVarItem SYNC_FLIGHT_DIRECTOR_Bank =
-  new SimVarItem { Def = Definition.AutoPilotFlightDirectorCurrentBank, SimVarName = "AUTOPILOT FLIGHT DIRECTOR BANK", Unit = Units.radians, CanSet = false };
+      new SimVarItem { Def = Definition.AutoPilotFlightDirectorCurrentBank, SimVarName = "AUTOPILOT FLIGHT DIRECTOR BANK", Unit = Units.radians, CanSet = false };
 
     #endregion
 
@@ -241,7 +326,10 @@ namespace MSFSTouchPortalPlugin.Objects.AutoPilot {
 
     [SimVarDataRequest]
     [TouchPortalAction("AutoPilotWingLeveler", "Wing Leveler", "MSFS", "Toggle/On/Off the Wing Leveler for auto pilot", "Wing Leveler - {0}")]
-    [TouchPortalActionChoice(new [] { "Toggle", "On", "Off" }, "Toggle")]
+    [TouchPortalActionChoice(new [] { "Toggle", "On", "Off" })]
+    [TouchPortalActionMapping("AP_WING_LEVELER", "Toggle")]
+    [TouchPortalActionMapping("AP_WING_LEVELER_ON", "On")]
+    [TouchPortalActionMapping("AP_WING_LEVELER_OFF", "Off")]
     [TouchPortalState("AutoPilotWingLeveler", "text", "AutoPilot Wing Leveler", "")]
     public static readonly SimVarItem AP_WING_LEVELER =
       new SimVarItem { Def = Definition.AutoPilotWingLeveler, SimVarName = "AUTOPILOT WING LEVELER", Unit = Units.Bool, CanSet = false };
@@ -252,7 +340,10 @@ namespace MSFSTouchPortalPlugin.Objects.AutoPilot {
 
     // TODO: Localizer state?
     [TouchPortalAction("AutoPilotLocalizer", "Localizer", "MSFS", "Toggle/On/Off the localizer for auto pilot", "Localizer - {0}")]
-    [TouchPortalActionChoice(new [] { "Toggle", "On", "Off" }, "Toggle")]
+    [TouchPortalActionChoice(new [] { "Toggle", "On", "Off" })]
+    [TouchPortalActionMapping("AP_LOC_HOLD", "Toggle")]
+    [TouchPortalActionMapping("AP_LOC_HOLD_ON", "On")]
+    [TouchPortalActionMapping("AP_LOC_HOLD_OFF", "Off")]
     public static object AP_LOCALIZER { get; }
 
     #endregion
@@ -260,8 +351,11 @@ namespace MSFSTouchPortalPlugin.Objects.AutoPilot {
     #region Yaw Dampener
 
     [SimVarDataRequest]
-    [TouchPortalAction("AutoPilotYawDampener", "Yaw Dampener", "MSFS", "Toggle/On/Off/Set the Yaw Dampener", "Yaw Dampener - {0}")]
-    [TouchPortalActionChoice(new [] { "Toggle", "On", "Off", "Set" }, "Toggle")]
+    [TouchPortalAction("AutoPilotYawDampener", "Yaw Dampener", "MSFS", "Toggle/On/Off the Yaw Dampener", "Yaw Dampener - {0}")]
+    [TouchPortalActionChoice(new [] { "Toggle", "On", "Off" })]
+    [TouchPortalActionMapping("YAW_DAMPER_TOGGLE", "Toggle")]
+    [TouchPortalActionMapping("YAW_DAMPER_ON", "On")]
+    [TouchPortalActionMapping("YAW_DAMPER_OFF", "Off")]
     [TouchPortalState("AutoPilotYawDampener", "text", "Yaw Dampener Status", "")]
     public static readonly SimVarItem AP_YAWDAMPENER =
       new SimVarItem { Def = Definition.AutoPilotYawDampener, SimVarName = "AUTOPILOT YAW DAMPER", Unit = Units.Bool, CanSet = false };
@@ -271,363 +365,43 @@ namespace MSFSTouchPortalPlugin.Objects.AutoPilot {
     #region Flight Level Control
 
     #endregion
-  }
 
-  [SimNotificationGroup(Groups.AutoPilot)]
-  [TouchPortalCategoryMapping("AutoPilot")]
-  internal enum AutoPilot {
-    // Placeholder to offset each enum for SimConnect
-    Init = 1000,
 
-    // TODO: ??
-    AP_N1_HOLD,
-    AP_N1_REF_INC,
-    AP_N1_REF_DEC,
-    AP_N1_REF_SET,
-    FLY_BY_WIRE_ELAC_TOGGLE,
-    FLY_BY_WIRE_FAC_TOGGLE,
-    FLY_BY_WIRE_SEC_TOGGLE,
+    #region Todo ??
 
-    AP_PANEL_SPEED_HOLD_TOGGLE, // With current speed
-    AP_PANEL_MACH_HOLD_TOGGLE, // WIth Current Mach
+    //AP_N1_HOLD,
+    //AP_N1_REF_INC,
+    //AP_N1_REF_DEC,
+    //AP_N1_REF_SET,
+    //FLY_BY_WIRE_ELAC_TOGGLE,
+    //FLY_BY_WIRE_FAC_TOGGLE,
+    //FLY_BY_WIRE_SEC_TOGGLE,
 
-    // Doesn't set value
-    AP_PANEL_ALTITUDE_HOLD,
-    AP_PANEL_ALTITUDE_ON,
-    AP_PANEL_ALTITUDE_OFF,
-    AP_PANEL_ALTITUDE_SET,
-    AP_PANEL_HEADING_HOLD,
-    AP_PANEL_HEADING_ON,
-    AP_PANEL_HEADING_OFF,
-    AP_PANEL_HEADING_SET,
-    AP_PANEL_MACH_HOLD,
-    AP_PANEL_MACH_ON,
-    AP_PANEL_MACH_OFF,
-    AP_PANEL_MACH_SET,
-    AP_PANEL_SPEED_HOLD,
-    AP_PANEL_SPEED_ON,
-    AP_PANEL_SPEED_OFF,
-    AP_PANEL_SPEED_SET,
-    AP_PANEL_VS_OFF,
-    AP_PANEL_VS_ON,
-    AP_PANEL_VS_SET,
+    //AP_PANEL_SPEED_HOLD_TOGGLE, // With current speed
+    //AP_PANEL_MACH_HOLD_TOGGLE, // WIth Current Mach
 
-    #region AutoPilot Master
-
-    // Auto Pilot
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotMaster", "Toggle")]
-    AP_MASTER,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotMaster", "On")]
-    AUTOPILOT_ON,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotMaster", "Off")]
-    AUTOPILOT_OFF,
+    //// Doesn't set value
+    //AP_PANEL_ALTITUDE_HOLD,
+    //AP_PANEL_ALTITUDE_ON,
+    //AP_PANEL_ALTITUDE_OFF,
+    //AP_PANEL_ALTITUDE_SET,
+    //AP_PANEL_HEADING_HOLD,
+    //AP_PANEL_HEADING_ON,
+    //AP_PANEL_HEADING_OFF,
+    //AP_PANEL_HEADING_SET,
+    //AP_PANEL_MACH_HOLD,
+    //AP_PANEL_MACH_ON,
+    //AP_PANEL_MACH_OFF,
+    //AP_PANEL_MACH_SET,
+    //AP_PANEL_SPEED_HOLD,
+    //AP_PANEL_SPEED_ON,
+    //AP_PANEL_SPEED_OFF,
+    //AP_PANEL_SPEED_SET,
+    //AP_PANEL_VS_OFF,
+    //AP_PANEL_VS_ON,
+    //AP_PANEL_VS_SET,
 
     #endregion
 
-    #region Attitude
-
-    // Attitude
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotAttitude", "Toggle")]
-    AP_ATT_HOLD,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotAttitude", "On")]
-    AP_ATT_HOLD_ON,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotAttitude", "Off")]
-    AP_ATT_HOLD_OFF,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotAttitudeVar", "Increase")]
-    AP_PITCH_REF_INC_UP,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotAttitudeVar", "Decrease")]
-    AP_PITCH_REF_INC_DN,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotAttitudeVar", "Set")]
-    AP_PITCH_REF_SELECT,
-
-    #endregion
-
-    #region Approach
-
-    // Approach Mode
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotApproach", "Toggle")]
-    AP_APR_HOLD,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotApproach", "On")]
-    AP_APR_HOLD_ON,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotApproach", "Off")]
-    AP_APR_HOLD_OFF,
-
-    #endregion
-
-    #region Bank
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotBanking", "Increase")]
-    AP_MAX_BANK_INC,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotBanking", "Decrease")]
-    AP_MAX_BANK_DEC,
-
-    #endregion
-
-    #region Heading
-
-    // Heading
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotHeading", "Toggle")]
-    AP_HDG_HOLD,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotHeading", "On")]
-    AP_HDG_HOLD_ON,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotHeading", "Off")]
-    AP_HDG_HOLD_OFF,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotHeadingVar", "Set")]
-    HEADING_BUG_SET,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotHeadingVar", "Increase")]
-    HEADING_BUG_INC,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotHeadingVar", "Decrease")]
-    HEADING_BUG_DEC,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotHeadingVar", "Select")]
-    HEADING_BUG_SELECT,
-
-    #endregion
-
-    #region Altitude
-
-    // Altitude
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotAltitude", "Toggle")]
-    AP_ALT_HOLD,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotAltitude", "On")]
-    AP_ALT_HOLD_ON,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotAltitude", "Off")]
-    AP_ALT_HOLD_OFF,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotAltitudeVar", "Increase")]
-    AP_ALT_VAR_INC,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotAltitudeVar", "Decrease")]
-    AP_ALT_VAR_DEC,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotAltitudeVar", "Select")]
-    ALTITUDE_BUG_SELECT,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotAltitudeVar", "Set")]
-    AP_ALT_VAR_SET_ENGLISH,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotAltitudeVar", "Set Metric")]
-    AP_ALT_VAR_SET_METRIC,
-
-    #endregion
-
-    #region Back Course
-
-    // Back course mode
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotBackCourse", "Toggle")]
-    AP_BC_HOLD,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotBackCourse", "On")]
-    AP_BC_HOLD_ON,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotBackCourse", "Off")]
-    AP_BC_HOLD_OFF,
-
-    #endregion
-
-    #region Nav1
-
-    // Nav1 mode
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotNav1", "Toggle")]
-    AP_NAV1_HOLD,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotNav1", "On")]
-    AP_NAV1_HOLD_ON,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotNav1", "Off")]
-    AP_NAV1_HOLD_OFF,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotNavSelect")]
-    AP_NAV_SELECT_SET,
-
-    #endregion
-
-    #region Vertical Speed
-
-    // Vertical Speed
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotVerticalSpeed", "Toggle")]
-    AP_PANEL_VS_HOLD,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotVerticalSpeedVar", "Increase")]
-    AP_VS_VAR_INC,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotVerticalSpeedVar", "Decrease")]
-    AP_VS_VAR_DEC,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotVerticalSpeedVar", "Set")]
-    AP_VS_VAR_SET_ENGLISH,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotVerticalSpeedVar", "Set Metric")]
-    AP_VS_VAR_SET_METRIC,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotVerticalSpeedVar", "Select")]
-    VSI_BUG_SELECT,
-
-    #endregion
-
-    #region Airspeed
-
-    // Air Speed
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotAirSpeed", "Toggle")]
-    AP_AIRSPEED_HOLD,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotAirSpeed", "On")]
-    AP_AIRSPEED_ON,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotAirSpeed", "Off")]
-    AP_AIRSPEED_OFF,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotAirSpeed", "Set")]
-    AP_AIRSPEED_SET,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotAirSpeedVar", "Increase")]
-    AP_SPD_VAR_INC,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotAirSpeedVar", "Decrease")]
-    AP_SPD_VAR_DEC,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotAirSpeedVar", "Set")]
-    AP_SPD_VAR_SET,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotAirSpeedVar", "Select")]
-    AIRSPEED_BUG_SELECT,
-
-    #endregion
-
-    #region AutoThrottle
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoThrottle", "Arm")]
-    AUTO_THROTTLE_ARM,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoThrottle", "GoAround")]
-    AUTO_THROTTLE_TO_GA,
-
-    #endregion
-
-    #region AutoBrake
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoBrake", "Increase")]
-    INCREASE_AUTOBRAKE_CONTROL,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoBrake", "Decrease")]
-    DECREASE_AUTOBRAKE_CONTROL,
-
-    #endregion
-
-    #region Mach
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotMach", "Toggle")]
-    AP_MACH_HOLD,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotMach", "On")]
-    AP_MACH_ON,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotMach", "Off")]
-    AP_MACH_OFF,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotMach", "Set")]
-    AP_MACH_SET,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotMachVar", "Increase")]
-    AP_MACH_VAR_INC,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotMachVar", "Decrease")]
-    AP_MACH_VAR_DEC,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotMachVar", "Set")]
-    AP_MACH_VAR_SET,
-
-    #endregion
-
-    #region Flight Director
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotFlightDirector", "Toggle")]
-    TOGGLE_FLIGHT_DIRECTOR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotFlightDirectorCurrentPitch")]
-    SYNC_FLIGHT_DIRECTOR_PITCH,
-
-    #endregion
-
-    #region Wing Leveler
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotWingLeveler", "Toggle")]
-    AP_WING_LEVELER,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotWingLeveler", "On")]
-    AP_WING_LEVELER_ON,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotWingLeveler", "Off")]
-    AP_WING_LEVELER_OFF,
-
-    #endregion
-
-    #region Localizer
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotLocalizer", "Toggle")]
-    AP_LOC_HOLD,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotLocalizer", "On")]
-    AP_LOC_HOLD_ON,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotLocalizer", "Off")]
-    AP_LOC_HOLD_OFF,
-
-    #endregion
-
-    #region Yaw Dampener
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotYawDampener", "Toggle")]
-    YAW_DAMPER_TOGGLE,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotYawDampener", "On")]
-    YAW_DAMPER_ON,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotYawDampener", "Off")]
-    YAW_DAMPER_OFF,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AutoPilotYawDampener", "Set")]
-    YAW_DAMPER_SET,
-
-    #endregion
   }
 }

--- a/MSFSTouchPortalPlugin/Objects/AutoPilot/AutoPilot.cs
+++ b/MSFSTouchPortalPlugin/Objects/AutoPilot/AutoPilot.cs
@@ -236,7 +236,7 @@ namespace MSFSTouchPortalPlugin.Objects.AutoPilot
     public static readonly SimVarItem AP_AIRSPEED_VAR =
       new SimVarItem { Def = Definition.AutoPilotAirSpeedVar, SimVarName = "AUTOPILOT AIRSPEED HOLD VAR", Unit = Units.knots, CanSet = false };
 
-    [TouchPortalAction("AutoPilotAirSpeedSet", "Airspeed Value Set", "MSFS", "Sets the airspeed value", "Set Airspeed Hold Value tp {0}")]
+    [TouchPortalAction("AutoPilotAirSpeedSet", "Airspeed Value Set", "MSFS", "Sets the airspeed value", "Set Airspeed Hold Value to {0}")]
     [TouchPortalActionText("1", 0, 5000)]
     [TouchPortalActionMapping("AP_SPD_VAR_SET")]
     public static object AP_AIRSPEED_SET { get; }
@@ -265,7 +265,7 @@ namespace MSFSTouchPortalPlugin.Objects.AutoPilot
     #region AutoBrake
 
     [TouchPortalAction("AutoBrake", "Auto Brake", "MSFS", "Increase/Decrease the auto brake", "Auto Brake - {0}", true)]
-    [TouchPortalActionChoice(new [] { "Increaes", "Decrease" })]
+    [TouchPortalActionChoice(new [] { "Increase", "Decrease" })]
     [TouchPortalActionMapping("INCREASE_AUTOBRAKE_CONTROL", "Increase")]
     [TouchPortalActionMapping("DECREASE_AUTOBRAKE_CONTROL", "Decrease")]
     public static object AUTO_BRAKE { get; }
@@ -286,14 +286,14 @@ namespace MSFSTouchPortalPlugin.Objects.AutoPilot
 
     [SimVarDataRequest]
     [TouchPortalAction("AutoPilotMachVar", "Mach Hold Value", "MSFS", "Sets the mach hold value", "Mach Hold Value - {0}")]
-    [TouchPortalActionChoice(new [] { "Select", "Increase", "Decrease" })]
+    [TouchPortalActionChoice(new [] { "Select", "Increase", "Decrease" }, "Increase")]
     [TouchPortalActionMapping("AP_MACH_VAR_INC", "Increase")]
     [TouchPortalActionMapping("AP_MACH_VAR_DEC", "Decrease")]
     [TouchPortalState("AutoPilotMachVar", "text", "AutoPilot Mach Value", "")]
     public static readonly SimVarItem AP_MACH_VAR =
       new SimVarItem { Def = Definition.AutoPilotMachVar, SimVarName = "AUTOPILOT MACH HOLD VAR", Unit = Units.number, CanSet = false };
 
-    [TouchPortalAction("AutoPilotMachSet", "Mach Hold Value Set", "MSFS", "Sets the mach hold value", "Set Mach Hold Value tp {0}")]
+    [TouchPortalAction("AutoPilotMachSet", "Mach Hold Value Set", "MSFS", "Sets the mach hold value", "Set Mach Hold Value to {0}")]
     [TouchPortalActionText("0", 0, 20)]
     [TouchPortalActionMapping("AP_MACH_VAR_SET")]
     public static object AP_MACH_SET { get; }

--- a/MSFSTouchPortalPlugin/Objects/AutoPilot/AutoPilot.cs
+++ b/MSFSTouchPortalPlugin/Objects/AutoPilot/AutoPilot.cs
@@ -46,14 +46,19 @@ namespace MSFSTouchPortalPlugin.Objects.AutoPilot
       new SimVarItem { Def = Definition.AutoPilotAttitudeHold, SimVarName = "AUTOPILOT ATTITUDE HOLD", Unit = Units.Bool, CanSet = false };
 
     [SimVarDataRequest]
-    [TouchPortalAction("AutoPilotAttitudeVar", "Attitude Hold Value", "MSFS", "Sets the attitude hold value", "Attitude Hold Value - {0}", true)]
+    [TouchPortalAction("AutoPilotAttitudeVar", "Attitude Hold Pitch Value", "MSFS", "Sets the attitude hold pitch value", "Attitude Hold Pitch Value - {0}", true)]
     [TouchPortalActionChoice(new [] { "Select", "Increase", "Decrease" })]
     [TouchPortalActionMapping("AP_PITCH_REF_INC_UP", "Increase")]
     [TouchPortalActionMapping("AP_PITCH_REF_INC_DN", "Decrease")]
-    [TouchPortalActionMapping("AP_PITCH_REF_SELECT", "Set")]
+    [TouchPortalActionMapping("AP_PITCH_REF_SELECT", "Select")]
     [TouchPortalState("AutoPilotAttitudeVar", "text", "AutoPilot Pitch Reference Value", "")]
     public static readonly SimVarItem AP_ATTITUDE_PITCH =
       new SimVarItem { Def = Definition.AutoPilotAttitudeVar, SimVarName = "AUTOPILOT PITCH HOLD REF", Unit = Units.radians, CanSet = false };
+
+    [TouchPortalAction("AutoPilotAttitudeSet", "Attitude Hold Pitch Value Set", "MSFS", "Sets the airspeed value", "Set Attitude Hold Pitch Value to {0} (-16383 - +16383)")]
+    [TouchPortalActionText("0", -16383, 16383)]
+    [TouchPortalActionMapping("AP_PITCH_REF_SET")]
+    public static object AP_ATTITUDE_PITCH_SET { get; }
 
     #endregion
 
@@ -227,17 +232,16 @@ namespace MSFSTouchPortalPlugin.Objects.AutoPilot
 
     [SimVarDataRequest]
     [TouchPortalAction("AutoPilotAirSpeedVar", "Airspeed Hold Value", "MSFS", "Adjusts the airspeed hold value", "Airspeed Hold Value - {0}", true)]
-    [TouchPortalActionChoice(new [] { "Select", "Increase", "Decrease", "Set" })]
+    [TouchPortalActionChoice(new [] { "Select", "Increase", "Decrease" })]
     [TouchPortalActionMapping("AIRSPEED_BUG_SELECT", "Select")]
     [TouchPortalActionMapping("AP_SPD_VAR_INC", "Increase")]
     [TouchPortalActionMapping("AP_SPD_VAR_DEC", "Decrease")]
-    [TouchPortalActionMapping("AP_SPD_VAR_SET", "Set")]
     [TouchPortalState("AutoPilotAirSpeedVar", "text", "AutoPilot Air Speed Value", "")]
     public static readonly SimVarItem AP_AIRSPEED_VAR =
       new SimVarItem { Def = Definition.AutoPilotAirSpeedVar, SimVarName = "AUTOPILOT AIRSPEED HOLD VAR", Unit = Units.knots, CanSet = false };
 
     [TouchPortalAction("AutoPilotAirSpeedSet", "Airspeed Value Set", "MSFS", "Sets the airspeed value", "Set Airspeed Hold Value to {0}")]
-    [TouchPortalActionText("1", 0, 5000)]
+    [TouchPortalActionText("0", 0, 5000)]
     [TouchPortalActionMapping("AP_SPD_VAR_SET")]
     public static object AP_AIRSPEED_SET { get; }
 

--- a/MSFSTouchPortalPlugin/Objects/Failures/Failures.cs
+++ b/MSFSTouchPortalPlugin/Objects/Failures/Failures.cs
@@ -2,57 +2,27 @@
 using MSFSTouchPortalPlugin.Enums;
 using TouchPortalExtension.Attributes;
 
-namespace MSFSTouchPortalPlugin.Objects.Failures {
+namespace MSFSTouchPortalPlugin.Objects.Failures 
+{
   [SimVarDataRequestGroup]
+  [SimNotificationGroup(Groups.Failures)]
   [TouchPortalCategory("Failures", "MSFS - Failures")]
   internal static class FailuresMapping {
 
     [TouchPortalAction("Failures", "Failures", "MSFS", "Toggle Failures", "Toggle Failures - {0}")]
-    [TouchPortalActionChoice(new [] { "Electrical", "Vacuum", "Pitot", "Static Port", "Hydraulic", "Total Brake", "Left Brake", "Right Brake", "Engine 1", "Engine 2", "Engine 3", "Engine 4" }, "Electrical")]
+    [TouchPortalActionChoice(new [] { "Electrical", "Vacuum", "Pitot", "Static Port", "Hydraulic", "Total Brake", "Left Brake", "Right Brake", "Engine 1", "Engine 2", "Engine 3", "Engine 4" })]
+    [TouchPortalActionMapping("TOGGLE_VACUUM_FAILURE", "Vacuum")]
+    [TouchPortalActionMapping("TOGGLE_ELECTRICAL_FAILURE", "Electrical")]
+    [TouchPortalActionMapping("TOGGLE_PITOT_BLOCKAGE", "Pitot")]
+    [TouchPortalActionMapping("TOGGLE_STATIC_PORT_BLOCKAGE", "Static Port")]
+    [TouchPortalActionMapping("TOGGLE_HYDRAULIC_FAILURE", "Hydraulic")]
+    [TouchPortalActionMapping("TOGGLE_TOTAL_BRAKE_FAILURE", "Total Brake")]
+    [TouchPortalActionMapping("TOGGLE_LEFT_BRAKE_FAILURE", "Left Brake")]
+    [TouchPortalActionMapping("TOGGLE_RIGHT_BRAKE_FAILURE", "Right Brake")]
+    [TouchPortalActionMapping("TOGGLE_ENGINE1_FAILURE", "Engine 1")]
+    [TouchPortalActionMapping("TOGGLE_ENGINE2_FAILURE", "Engine 2")]
+    [TouchPortalActionMapping("TOGGLE_ENGINE3_FAILURE", "Engine 3")]
+    [TouchPortalActionMapping("TOGGLE_ENGINE4_FAILURE", "Engine 4")]
     public static object FAILURES { get; }
-  }
-
-  [SimNotificationGroup(Groups.Failures)]
-  [TouchPortalCategoryMapping("Failures")]
-  internal enum Failures {
-    // Placeholder to offset each enum for SimConnect
-    Init = 9000,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("Failures", "Vacuum")]
-    TOGGLE_VACUUM_FAILURE,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Failures", "Electrical")]
-    TOGGLE_ELECTRICAL_FAILURE,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Failures", "Pitot")]
-    TOGGLE_PITOT_BLOCKAGE,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Failures", "Static Port")]
-    TOGGLE_STATIC_PORT_BLOCKAGE,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Failures", "Hydraulic")]
-    TOGGLE_HYDRAULIC_FAILURE,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Failures", "Total Brake")]
-    TOGGLE_TOTAL_BRAKE_FAILURE,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Failures", "Left Brake")]
-    TOGGLE_LEFT_BRAKE_FAILURE,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Failures", "Right Brake")]
-    TOGGLE_RIGHT_BRAKE_FAILURE,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Failures", "Engine 1")]
-    TOGGLE_ENGINE1_FAILURE,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Failures", "Engine 2")]
-    TOGGLE_ENGINE2_FAILURE,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Failures", "Engine 3")]
-    TOGGLE_ENGINE3_FAILURE,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Failures", "Engine 4")]
-    TOGGLE_ENGINE4_FAILURE,
   }
 }

--- a/MSFSTouchPortalPlugin/Objects/FlightSystems/FlightSystems.cs
+++ b/MSFSTouchPortalPlugin/Objects/FlightSystems/FlightSystems.cs
@@ -20,6 +20,7 @@ namespace MSFSTouchPortalPlugin.Objects.FlightSystems
 
     [TouchPortalAction("AileronsSet", "Ailerons Set", "MSFS", " Set Ailerons", "Ailerons set to {0} (-16383 - +16383)")]
     [TouchPortalActionText("0", -16383, 16383)]
+    [TouchPortalActionMapping("AILERONS_SET")]
     public static object AileronsSet { get; }
 
     #endregion
@@ -42,7 +43,7 @@ namespace MSFSTouchPortalPlugin.Objects.FlightSystems
     #region Brakes
 
     [TouchPortalAction("Brakes", "Brakes", "MSFS", "Brakes", "Brakes - {0}", true)]
-    [TouchPortalActionChoice(new [] { "All", "Left", "Right" }, "All")]
+    [TouchPortalActionChoice(new [] { "All", "Left", "Right" })]
     [TouchPortalActionMapping("BRAKES", "All")]
     [TouchPortalActionMapping("BRAKES_LEFT", "Left")]
     [TouchPortalActionMapping("BRAKES_RIGHT", "Right")]
@@ -74,6 +75,7 @@ namespace MSFSTouchPortalPlugin.Objects.FlightSystems
 
     [TouchPortalAction("FlapsSet", "Flaps Set", "MSFS", " Set Flaps", "Flaps set to {0} (0 - +16383)")]
     [TouchPortalActionText("0", 0, 16383)]
+    [TouchPortalActionMapping("FLAPS_SET")]
     public static object FlapsSet { get; }
 
 
@@ -131,15 +133,15 @@ namespace MSFSTouchPortalPlugin.Objects.FlightSystems
     #region Rudder
 
     [TouchPortalAction("Rudder", "Rudder", "MSFS", "Rudder", "Rudder - {0}", true)]
-    [TouchPortalActionChoice(new [] { "Center", "Left", "Right", "Set" })]
-    [TouchPortalActionMapping("RUDDER_SET", "Set")]
-    [TouchPortalActionMapping("RUDDER_LEFT", "Left")]
+    [TouchPortalActionChoice(new [] { "Center", "Left", "Right" })]
     [TouchPortalActionMapping("RUDDER_CENTER", "Center")]
+    [TouchPortalActionMapping("RUDDER_LEFT", "Left")]
     [TouchPortalActionMapping("RUDDER_RIGHT", "Right")]
     public static object Rudder { get; }
 
     [TouchPortalAction("RudderSet", "Rudder Set", "MSFS", " Set Rudder", "Rudder set to {0} (-16383 - +16383)")]
     [TouchPortalActionText("0", -16383, 16383)]
+    [TouchPortalActionMapping("RUDDER_SET")]
     public static object RudderSet { get; }
 
     #endregion

--- a/MSFSTouchPortalPlugin/Objects/FlightSystems/FlightSystems.cs
+++ b/MSFSTouchPortalPlugin/Objects/FlightSystems/FlightSystems.cs
@@ -3,15 +3,39 @@ using MSFSTouchPortalPlugin.Constants;
 using MSFSTouchPortalPlugin.Enums;
 using TouchPortalExtension.Attributes;
 
-namespace MSFSTouchPortalPlugin.Objects.FlightSystems {
+namespace MSFSTouchPortalPlugin.Objects.FlightSystems
+{
   [SimVarDataRequestGroup]
+  [SimNotificationGroup(Groups.FlightSystems)]
   [TouchPortalCategory("FlightSystems", "MSFS - Flight Systems")]
   internal static class FlightSystemsMapping {
     #region Ailerons
 
     [TouchPortalAction("Ailerons", "Ailerons", "MSFS", "Ailerons", "Ailerons - {0}", true)]
-    [TouchPortalActionChoice(new [] { "Center", "Left", "Right", "Set" }, "Center")]
-    public static object AILERONS { get; }
+    [TouchPortalActionChoice(new [] { "Center", "Left", "Right" })]
+    [TouchPortalActionMapping("CENTER_AILER_RUDDER", "Center")]
+    [TouchPortalActionMapping("AILERONS_LEFT", "Left")]
+    [TouchPortalActionMapping("AILERONS_RIGHT", "Right")]
+    public static object Ailerons { get; }
+
+    [TouchPortalAction("AileronsSet", "Ailerons Set", "MSFS", " Set Ailerons", "Ailerons set to {0} (-16383 - +16383)")]
+    [TouchPortalActionText("0", -16383, 16383)]
+    public static object AileronsSet { get; }
+
+    #endregion
+
+    #region Elevator
+
+    [TouchPortalAction("Elevator", "Elevator", "MSFS", "Elevator", "Elevator - {0}", true)]
+    [TouchPortalActionChoice(new[] { "Up", "Down" })]
+    [TouchPortalActionMapping("ELEV_UP", "Up")]
+    [TouchPortalActionMapping("ELEV_DOWN", "Down")]
+    public static object Elevator { get; }
+
+    [TouchPortalAction("ElevatorSet", "Elevator Set", "MSFS", " Set Elevator", "Elevator set to {0} (-16383 - +16383)")]
+    [TouchPortalActionText("0", -16383, 16383)]
+    [TouchPortalActionMapping("ELEVATOR_SET")]
+    public static object ElevatorSet { get; }
 
     #endregion
 
@@ -19,13 +43,16 @@ namespace MSFSTouchPortalPlugin.Objects.FlightSystems {
 
     [TouchPortalAction("Brakes", "Brakes", "MSFS", "Brakes", "Brakes - {0}", true)]
     [TouchPortalActionChoice(new [] { "All", "Left", "Right" }, "All")]
-    public static object BRAKES { get; }
-
+    [TouchPortalActionMapping("BRAKES", "All")]
+    [TouchPortalActionMapping("BRAKES_LEFT", "Left")]
+    [TouchPortalActionMapping("BRAKES_RIGHT", "Right")]
+    public static object Brakes { get; }
 
     [SimVarDataRequest]
     [TouchPortalAction("ParkingBreak", "Toggle Parking Brake", "MSFS", "Toggle Parking Brake", "Toggle Parking Brake")]
+    [TouchPortalActionMapping("PARKING_BRAKES")]
     [TouchPortalState("ParkingBrakeIndicator", "text", "Parking Brake Indicator true/false", "")]
-    public static readonly SimVarItem PARKING_BRAKE = new SimVarItem { Def = Definition.ParkingBrakeIndicator, SimVarName = "BRAKE PARKING POSITION", Unit = Units.Bool, CanSet = false };
+    public static readonly SimVarItem ParkingBrake = new SimVarItem { Def = Definition.ParkingBrakeIndicator, SimVarName = "BRAKE PARKING POSITION", Unit = Units.Bool, CanSet = false };
 
     #endregion
 
@@ -33,43 +60,70 @@ namespace MSFSTouchPortalPlugin.Objects.FlightSystems {
 
     [SimVarDataRequest]
     [TouchPortalAction("Flaps", "Flaps", "MSFS", "Flaps", "Flaps - {0}")]
-    [TouchPortalActionChoice(new [] { "Up", "Down", "Increase", "Decrease", "1", "2", "3", "Set" }, "Up")]
+    [TouchPortalActionChoice(new [] { "Up", "Down", "Increase", "Decrease", "1", "2", "3", "4" })]
+    [TouchPortalActionMapping("FLAPS_UP", "Up")]
+    [TouchPortalActionMapping("FLAPS_DOWN", "Down")]
+    [TouchPortalActionMapping("FLAPS_INCR", "Increase")]
+    [TouchPortalActionMapping("FLAPS_DECR", "Decrease")]
+    [TouchPortalActionMapping("FLAPS_1", "1")]
+    [TouchPortalActionMapping("FLAPS_2", "2")]
+    [TouchPortalActionMapping("FLAPS_3", "3")]
+    [TouchPortalActionMapping("FLAPS_3", "4")]
     [TouchPortalState("FlapsHandlePercent", "text", "Flaps Handle Percentage", "")]
     public static readonly SimVarItem FlapsHandlePercent = new SimVarItem { Def = Definition.FlapsHandlePercent, SimVarName = "FLAPS HANDLE PERCENT", Unit = Units.percent, CanSet = false, StringFormat = "{0:0.0#}" };
 
+    [TouchPortalAction("FlapsSet", "Flaps Set", "MSFS", " Set Flaps", "Flaps set to {0} (0 - +16383)")]
+    [TouchPortalActionText("0", 0, 16383)]
+    public static object FlapsSet { get; }
+
+
     [TouchPortalAction("CowlFlapsAll", "Cowl Flaps All", "MSFS", "Cowl Flaps All", "Cowl Flaps All - {0}", true)]
-    [TouchPortalActionChoice(new [] { "Increase", "Decrease" }, "Increase")]
-    public static object COWL_FLAPS_All { get; }
+    [TouchPortalActionChoice(new [] { "Increase", "Decrease" })]
+    [TouchPortalActionMapping("INC_COWL_FLAPS", "Increase")]
+    [TouchPortalActionMapping("DEC_COWL_FLAPS", "Decrease")]
+    public static object CowlFlapsAll { get; }
 
     [TouchPortalAction("CowlFlaps1", "Cowl Flaps 1", "MSFS", "Cowl Flaps 1", "Cowl Flaps 1 - {0}", true)]
-    [TouchPortalActionChoice(new [] { "Increase", "Decrease" }, "Increase")]
+    [TouchPortalActionChoice(new [] { "Increase", "Decrease" })]
+    [TouchPortalActionMapping("INC_COWL_FLAPS1", "Increase")]
+    [TouchPortalActionMapping("DEC_COWL_FLAPS1", "Decrease")]
     [TouchPortalState("CowlFlaps1Percent", "text", "Cowl Flaps 1 Opened Percentage", "")]
-    public static readonly SimVarItem COWL_FLAPS_1 = new SimVarItem { Def = Definition.CowlFlaps1Percent, SimVarName = "RECIP ENG COWL FLAP POSITION:1", Unit = Units.percent, CanSet = true, StringFormat = "{0:0.0#}" };
+    public static readonly SimVarItem CowlFlaps1 = new SimVarItem { Def = Definition.CowlFlaps1Percent, SimVarName = "RECIP ENG COWL FLAP POSITION:1", Unit = Units.percent, CanSet = true, StringFormat = "{0:0.0#}" };
 
     [TouchPortalAction("CowlFlaps2", "Cowl Flaps 2", "MSFS", "Cowl Flaps 2", "Cowl Flaps 2 - {0}", true)]
-    [TouchPortalActionChoice(new [] { "Increase", "Decrease" }, "Increase")]
+    [TouchPortalActionChoice(new [] { "Increase", "Decrease" })]
+    [TouchPortalActionMapping("INC_COWL_FLAPS2", "Increase")]
+    [TouchPortalActionMapping("DEC_COWL_FLAPS2", "Decrease")]
     [TouchPortalState("CowlFlaps2Percent", "text", "Cowl Flaps 2 Opened Percentage", "")]
-    public static readonly SimVarItem COWL_FLAPS_2 = new SimVarItem { Def = Definition.CowlFlaps2Percent, SimVarName = "RECIP ENG COWL FLAP POSITION:2", Unit = Units.percent, CanSet = true, StringFormat = "{0:0.0#}" };
+    public static readonly SimVarItem CowlFlaps2 = new SimVarItem { Def = Definition.CowlFlaps2Percent, SimVarName = "RECIP ENG COWL FLAP POSITION:2", Unit = Units.percent, CanSet = true, StringFormat = "{0:0.0#}" };
 
     [TouchPortalAction("CowlFlaps3", "Cowl Flaps 3", "MSFS", "Cowl Flaps 3", "Cowl Flaps 3 - {0}", true)]
-    [TouchPortalActionChoice(new [] { "Increase", "Decrease" }, "Increase")]
+    [TouchPortalActionChoice(new [] { "Increase", "Decrease" })]
+    [TouchPortalActionMapping("INC_COWL_FLAPS3", "Increase")]
+    [TouchPortalActionMapping("DEC_COWL_FLAPS3", "Decrease")]
     [TouchPortalState("CowlFlaps3Percent", "text", "Cowl Flaps 3 Opened Percentage", "")]
-    public static readonly SimVarItem COWL_FLAPS_3 = new SimVarItem { Def = Definition.CowlFlaps3Percent, SimVarName = "RECIP ENG COWL FLAP POSITION:3", Unit = Units.percent, CanSet = true, StringFormat = "{0:0.0#}" };
+    public static readonly SimVarItem CowlFlaps3 = new SimVarItem { Def = Definition.CowlFlaps3Percent, SimVarName = "RECIP ENG COWL FLAP POSITION:3", Unit = Units.percent, CanSet = true, StringFormat = "{0:0.0#}" };
 
     [TouchPortalAction("CowlFlaps4", "Cowl Flaps 4", "MSFS", "Cowl Flaps 4", "Cowl Flaps 4 - {0}", true)]
-    [TouchPortalActionChoice(new [] { "Increase", "Decrease" }, "Increase")]
+    [TouchPortalActionChoice(new [] { "Increase", "Decrease" })]
+    [TouchPortalActionMapping("INC_COWL_FLAPS4", "Increase")]
+    [TouchPortalActionMapping("DEC_COWL_FLAPS4", "Decrease")]
     [TouchPortalState("CowlFlaps4Percent", "text", "Cowl Flaps 4 Opened Percentage", "")]
-    public static readonly SimVarItem COWL_FLAPS_4 = new SimVarItem { Def = Definition.CowlFlaps4Percent, SimVarName = "RECIP ENG COWL FLAP POSITION:4", Unit = Units.percent, CanSet = true, StringFormat = "{0:0.0#}" };
+    public static readonly SimVarItem CowlFlaps4 = new SimVarItem { Def = Definition.CowlFlaps4Percent, SimVarName = "RECIP ENG COWL FLAP POSITION:4", Unit = Units.percent, CanSet = true, StringFormat = "{0:0.0#}" };
 
     #endregion
 
     #region Gear
 
     [SimVarDataRequest]
-    [TouchPortalAction("Gear", "Gear Manipulation", "MSFS", "Gear Manipulation", "Gear - {0}")]
-    [TouchPortalActionChoice(new [] { "Toggle", "Up", "Down", "Set", "Pump" }, "Toggle")]
+    [TouchPortalAction("Gear", "Gear Manipulation", "MSFS", "Gear Manipulation", "Gear - {0}", true)]
+    [TouchPortalActionChoice(new [] { "Toggle", "Up", "Down", "Pump" })]
+    [TouchPortalActionMapping("GEAR_TOGGLE", "Toggle")]
+    [TouchPortalActionMapping("GEAR_UP", "Up")]
+    [TouchPortalActionMapping("GEAR_DOWN", "Down")]
+    [TouchPortalActionMapping("GEAR_PUMP", "Pump")]
     [TouchPortalState("GearTotalExtended", "text", "Total percentage of gear extended", "")]
-    public static readonly SimVarItem GEAR =
+    public static readonly SimVarItem Gear =
       new SimVarItem { Def = Definition.GearTotalExtended, SimVarName = "GEAR TOTAL PCT EXTENDED", Unit = Units.percentage, CanSet = false };
 
     #endregion
@@ -77,20 +131,39 @@ namespace MSFSTouchPortalPlugin.Objects.FlightSystems {
     #region Rudder
 
     [TouchPortalAction("Rudder", "Rudder", "MSFS", "Rudder", "Rudder - {0}", true)]
-    [TouchPortalActionChoice(new [] { "Center", "Left", "Right", "Set" }, "Center")]
-    public static object RUDDER { get; }
+    [TouchPortalActionChoice(new [] { "Center", "Left", "Right", "Set" })]
+    [TouchPortalActionMapping("RUDDER_SET", "Set")]
+    [TouchPortalActionMapping("RUDDER_LEFT", "Left")]
+    [TouchPortalActionMapping("RUDDER_CENTER", "Center")]
+    [TouchPortalActionMapping("RUDDER_RIGHT", "Right")]
+    public static object Rudder { get; }
+
+    [TouchPortalAction("RudderSet", "Rudder Set", "MSFS", " Set Rudder", "Rudder set to {0} (-16383 - +16383)")]
+    [TouchPortalActionText("0", -16383, 16383)]
+    public static object RudderSet { get; }
 
     #endregion
 
     #region Spoilers
 
     [TouchPortalAction("Spoilers", "Spoilers", "MSFS", "Spoilers", "Spoilers - {0}")]
-    [TouchPortalActionChoice(new [] { "Toggle", "On", "Off", "Set" }, "Toggle")]
-    public static object SPOILERS { get; }
+    [TouchPortalActionChoice(new [] { "Toggle", "On", "Off", "Set" })]
+    [TouchPortalActionMapping("SPOILERS_TOGGLE", "Toggle")]
+    [TouchPortalActionMapping("SPOILERS_ON", "On")]
+    [TouchPortalActionMapping("SPOILERS_OFF", "Off")]
+    public static object Spoilers { get; }
+
+    [TouchPortalAction("SpoilersSet", "Spoilers Set", "MSFS", " Set Spoilers", "Spoilers set to {0} (0- +16383)")]
+    [TouchPortalActionText("0", 0, 16383)]
+    [TouchPortalActionMapping("SPOILERS_SET")]
+    public static object SpoilersSet { get; }
 
     [TouchPortalAction("SpoilersArm", "Spoilers Arm", "MSFS", "Spoilers Arm", "Spoilers Arm - {0}")]
-    [TouchPortalActionChoice(new [] { "Toggle", "On", "Off", "Set" }, "Toggle")]
-    public static object SPOILERS_ARM { get; }
+    [TouchPortalActionChoice(new [] { "Toggle", "On", "Off" })]
+    [TouchPortalActionMapping("SPOILERS_ARM_TOGGLE", "Toggle")]
+    [TouchPortalActionMapping("SPOILERS_ARM_ON", "On")]
+    [TouchPortalActionMapping("SPOILERS_ARM_OFF", "Off")]
+    public static object SpoilersArm { get; }
 
     #endregion
 
@@ -99,233 +172,62 @@ namespace MSFSTouchPortalPlugin.Objects.FlightSystems {
     [SimVarDataRequest]
     [TouchPortalAction("AileronTrim", "Aileron Trim", "MSFS", "Aileron Trim", "Aileron Trim - {0}", true)]
     [TouchPortalActionChoice(new [] { "Left", "Right" }, "Left")]
+    [TouchPortalActionMapping("AILERON_TRIM_LEFT", "Left")]
+    [TouchPortalActionMapping("AILERON_TRIM_RIGHT", "Right")]
     [TouchPortalState("AileronTrim", "text", "Aileron Trim Angle", "")]
-    public static readonly SimVarItem AILERON_TRIM =
+    public static readonly SimVarItem AileronTrim =
       new SimVarItem { Def = Definition.AileronTrim, SimVarName = "AILERON TRIM", Unit = Units.degrees, CanSet = false, StringFormat = "{0:0.0#}" };
+
+    [TouchPortalAction("AileronTrimSet", "Aileron Trim Set", "MSFS", " Set Aileron Trim", "Aileron Trim set to {0} (0 - +16383)")]
+    [TouchPortalActionText("0", 0, 16383)]
+    [TouchPortalActionMapping("AILERON_TRIM_SET")]
+    public static object AileronTrimSet { get; }
+
 
     [SimVarDataRequest]
     [TouchPortalAction("ElevatorTrim", "Elevator Trim", "MSFS", "Elevator Trim", "Elevator Trim - {0}", true)]
-    [TouchPortalActionChoice(new [] { "Up", "Down" }, "Up")]
+    [TouchPortalActionChoice(new [] { "Up", "Down" })]
+    [TouchPortalActionMapping("ELEV_TRIM_DN", "Down")]
+    [TouchPortalActionMapping("ELEV_TRIM_UP", "Up")]
     [TouchPortalState("ElevatorTrim", "text", "Elevator Trim Angle", "")]
-    public static readonly SimVarItem ELEVATOR_TRIM =
+    public static readonly SimVarItem ElevatorTrim =
       new SimVarItem { Def = Definition.ElevatorTrim, SimVarName = "ELEVATOR TRIM POSITION", Unit = Units.degrees, CanSet = true, StringFormat = "{0:0.0#}" };
+
+    [TouchPortalAction("ElevatorTrimSet", "Elevator Trim Set", "MSFS", " Set Elevator Trim", "Elevator Trim set to {0} (0 - +16383)")]
+    [TouchPortalActionText("0", 0, 16383)]
+    [TouchPortalActionMapping("ELEVATOR_TRIM_SET")]
+    public static object ElevatorTrimSet { get; }
+
 
     [SimVarDataRequest]
     [TouchPortalAction("RudderTrim", "Rudder Trim", "MSFS", "Rudder Trim", "Rudder Trim - {0}", true)]
-    [TouchPortalActionChoice(new [] { "Left", "Right" }, "Left")]
+    [TouchPortalActionChoice(new [] { "Left", "Right" })]
+    [TouchPortalActionMapping("RUDDER_TRIM_LEFT", "Left")]
+    [TouchPortalActionMapping("RUDDER_TRIM_RIGHT", "Right")]
     [TouchPortalState("RudderTrim", "text", "Rudder Trim Angle", "")]
-    public static readonly SimVarItem RUDDER_TRIM =
+    public static readonly SimVarItem RudderTrim =
       new SimVarItem { Def = Definition.RudderTrim, SimVarName = "RUDDER TRIM", Unit = Units.degrees, CanSet = false, StringFormat = "{0:0.0#}" };
+
+    [TouchPortalAction("RudderTrimSet", "Rudder Trim Set", "MSFS", " Set Rudder Trim", "Rudder Trim set to {0} (0 - +16383)")]
+    [TouchPortalActionText("0", 0, 16383)]
+    [TouchPortalActionMapping("RUDDER_TRIM_SET")]
+    public static object RudderTrimSet { get; }
 
 
     [SimVarDataRequest] // XYZ
     [TouchPortalState("AileronTrimPct", "text", "Aileron Trim Percent", "0")]
-    public static readonly SimVarItem AILERON_TRIM_PCT =
+    public static readonly SimVarItem AileronTrimPct =
       new SimVarItem { Def = Definition.AileronTrimPct, SimVarName = "AILERON TRIM PCT", Unit = Units.percentover100, CanSet = true, StringFormat = "{0:F1}" };
 
     [SimVarDataRequest]
     [TouchPortalState("ElevatorTrimPct", "text", "Elevator Trim Percent", "0")]
-    public static readonly SimVarItem ELEVATOR_TRIM_PCT =
+    public static readonly SimVarItem ElevatorTrimPct =
       new SimVarItem { Def = Definition.ElevatorTrimPct, SimVarName = "ELEVATOR TRIM PCT", Unit = Units.percentover100, CanSet = false, StringFormat = "{0:F1}" };
 
     [SimVarDataRequest]
     [TouchPortalState("RudderTrimPct", "text", "Rudder Trim Percent", "0")]
-    public static readonly SimVarItem RUDDER_TRIM_PCT =
+    public static readonly SimVarItem RudderTrimPct =
       new SimVarItem { Def = Definition.RudderTrimPct, SimVarName = "RUDDER TRIM PCT", Unit = Units.percentover100, CanSet = true, StringFormat = "{0:F1}" };
-    #endregion
-  }
-
-  [SimNotificationGroup(Groups.FlightSystems)]
-  [TouchPortalCategoryMapping("FlightSystems")]
-  internal enum FlightSystems {
-    // Placeholder to offset each enum for SimConnect
-    Init = 7000,
-
-    #region Ailerons
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("Ailerons", "Set")]
-    AILERON_SET,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Ailerons", "Left")]
-    AILERONS_LEFT,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Ailerons", "Center")]
-    CENTER_AILER_RUDDER,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Ailerons", "Right")]
-    AILERONS_RIGHT,
-
-    #endregion
-
-    #region Brakes
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("Brakes", "All")]
-    BRAKES,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Brakes", "Left")]
-    BRAKES_LEFT,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Brakes", "Right")]
-    BRAKES_RIGHT,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("ParkingBreak")]
-    PARKING_BRAKES,
-
-    #endregion
-
-    #region Flaps
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("Flaps", "Up")]
-    FLAPS_UP,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Flaps", "Down")]
-    FLAPS_DOWN,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Flaps", "1")]
-    FLAPS_1,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Flaps", "2")]
-    FLAPS_2,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Flaps", "3")]
-    FLAPS_3,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Flaps", "Increase")]
-    FLAPS_INCR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Flaps", "Decrease")]
-    FLAPS_DECR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Flaps", "Set")]
-    FLAPS_SET,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("CowlFlapsAll", "Increase")]
-    INC_COWL_FLAPS,
-    [SimActionEvent]
-    [TouchPortalActionMapping("CowlFlapsAll", "Decrease")]
-    DEC_COWL_FLAPS,
-    [SimActionEvent]
-    [TouchPortalActionMapping("CowlFlaps1", "Increase")]
-    INC_COWL_FLAPS1,
-    [SimActionEvent]
-    [TouchPortalActionMapping("CowlFlaps1", "Decrease")]
-    DEC_COWL_FLAPS1,
-    [SimActionEvent]
-    [TouchPortalActionMapping("CowlFlaps2", "Increase")]
-    INC_COWL_FLAPS2,
-    [SimActionEvent]
-    [TouchPortalActionMapping("CowlFlaps2", "Decrease")]
-    DEC_COWL_FLAPS2,
-    [SimActionEvent]
-    [TouchPortalActionMapping("CowlFlaps3", "Increase")]
-    INC_COWL_FLAPS3,
-    [SimActionEvent]
-    [TouchPortalActionMapping("CowlFlaps3", "Decrease")]
-    DEC_COWL_FLAPS3,
-    [SimActionEvent]
-    [TouchPortalActionMapping("CowlFlaps4", "Increase")]
-    INC_COWL_FLAPS4,
-    [SimActionEvent]
-    [TouchPortalActionMapping("CowlFlaps4", "Decrease")]
-    DEC_COWL_FLAPS4,
-
-    #endregion
-
-    #region Gear
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("Gear", "Toggle")]
-    GEAR_TOGGLE,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Gear", "Set")]
-    GEAR_SET,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Gear", "Pump")]
-    GEAR_PUMP,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Gear", "Up")]
-    GEAR_UP,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Gear", "Down")]
-    GEAR_DOWN,
-
-    #endregion
-
-    #region Rudder
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("Rudder", "Set")]
-    RUDDER_SET,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Rudder", "Left")]
-    RUDDER_LEFT,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Rudder", "Center")]
-    RUDDER_CENTER,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Rudder", "Right")]
-    RUDDER_RIGHT,
-
-    #endregion
-
-    #region Spoilers
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("Spoilers", "Toggle")]
-    SPOILERS_TOGGLE,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Spoilers", "On")]
-    SPOILERS_ON,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Spoilers", "Off")]
-    SPOILERS_OFF,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Spoilers", "Set")]
-    SPOILERS_SET,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("SpoilersArm", "Toggle")]
-    SPOILERS_ARM_TOGGLE,
-    [SimActionEvent]
-    [TouchPortalActionMapping("SpoilersArm", "On")]
-    SPOILERS_ARM_ON,
-    [SimActionEvent]
-    [TouchPortalActionMapping("SpoilersArm", "Off")]
-    SPOILERS_ARM_OFF,
-    [SimActionEvent]
-    [TouchPortalActionMapping("SpoilersArm", "Set")]
-    SPOILERS_ARM_SET,
-
-    #endregion
-
-    #region Trimming
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("AileronTrim", "Left")]
-    AILERON_TRIM_LEFT,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AileronTrim", "Right")]
-    AILERON_TRIM_RIGHT,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("ElevatorTrim", "Down")]
-    ELEV_TRIM_DN,
-    [SimActionEvent]
-    [TouchPortalActionMapping("ElevatorTrim", "Up")]
-    ELEV_TRIM_UP,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("RudderTrim", "Left")]
-    RUDDER_TRIM_LEFT,
-    [SimActionEvent]
-    [TouchPortalActionMapping("RudderTrim", "Right")]
-    RUDDER_TRIM_RIGHT,
-
     #endregion
   }
 }

--- a/MSFSTouchPortalPlugin/Objects/FlightSystems/FlightSystems.cs
+++ b/MSFSTouchPortalPlugin/Objects/FlightSystems/FlightSystems.cs
@@ -20,7 +20,7 @@ namespace MSFSTouchPortalPlugin.Objects.FlightSystems
 
     [TouchPortalAction("AileronsSet", "Ailerons Set", "MSFS", " Set Ailerons", "Ailerons set to {0} (-16383 - +16383)")]
     [TouchPortalActionText("0", -16383, 16383)]
-    [TouchPortalActionMapping("AILERONS_SET")]
+    [TouchPortalActionMapping("AILERON_SET")]
     public static object AileronsSet { get; }
 
     #endregion
@@ -149,7 +149,7 @@ namespace MSFSTouchPortalPlugin.Objects.FlightSystems
     #region Spoilers
 
     [TouchPortalAction("Spoilers", "Spoilers", "MSFS", "Spoilers", "Spoilers - {0}")]
-    [TouchPortalActionChoice(new [] { "Toggle", "On", "Off", "Set" })]
+    [TouchPortalActionChoice(new [] { "Toggle", "On", "Off" })]
     [TouchPortalActionMapping("SPOILERS_TOGGLE", "Toggle")]
     [TouchPortalActionMapping("SPOILERS_ON", "On")]
     [TouchPortalActionMapping("SPOILERS_OFF", "Off")]
@@ -180,8 +180,8 @@ namespace MSFSTouchPortalPlugin.Objects.FlightSystems
     public static readonly SimVarItem AileronTrim =
       new SimVarItem { Def = Definition.AileronTrim, SimVarName = "AILERON TRIM", Unit = Units.degrees, CanSet = false, StringFormat = "{0:0.0#}" };
 
-    [TouchPortalAction("AileronTrimSet", "Aileron Trim Set", "MSFS", " Set Aileron Trim", "Aileron Trim set to {0} (0 - +16383)")]
-    [TouchPortalActionText("0", 0, 16383)]
+    [TouchPortalAction("AileronTrimSet", "Aileron Trim Set", "MSFS", " Set Aileron Trim", "Aileron Trim set to {0}% (-100 - +100)")]
+    [TouchPortalActionText("0", -100, 100)]
     [TouchPortalActionMapping("AILERON_TRIM_SET")]
     public static object AileronTrimSet { get; }
 
@@ -195,8 +195,8 @@ namespace MSFSTouchPortalPlugin.Objects.FlightSystems
     public static readonly SimVarItem ElevatorTrim =
       new SimVarItem { Def = Definition.ElevatorTrim, SimVarName = "ELEVATOR TRIM POSITION", Unit = Units.degrees, CanSet = true, StringFormat = "{0:0.0#}" };
 
-    [TouchPortalAction("ElevatorTrimSet", "Elevator Trim Set", "MSFS", " Set Elevator Trim", "Elevator Trim set to {0} (0 - +16383)")]
-    [TouchPortalActionText("0", 0, 16383)]
+    [TouchPortalAction("ElevatorTrimSet", "Elevator Trim Set", "MSFS", " Set Elevator Trim", "Elevator Trim set to {0} (-16383 - +16383)")]
+    [TouchPortalActionText("0", -16383, 16383)]
     [TouchPortalActionMapping("ELEVATOR_TRIM_SET")]
     public static object ElevatorTrimSet { get; }
 
@@ -210,8 +210,8 @@ namespace MSFSTouchPortalPlugin.Objects.FlightSystems
     public static readonly SimVarItem RudderTrim =
       new SimVarItem { Def = Definition.RudderTrim, SimVarName = "RUDDER TRIM", Unit = Units.degrees, CanSet = false, StringFormat = "{0:0.0#}" };
 
-    [TouchPortalAction("RudderTrimSet", "Rudder Trim Set", "MSFS", " Set Rudder Trim", "Rudder Trim set to {0} (0 - +16383)")]
-    [TouchPortalActionText("0", 0, 16383)]
+    [TouchPortalAction("RudderTrimSet", "Rudder Trim Set", "MSFS", " Set Rudder Trim", "Rudder Trim set to {0}% (-100 - +100)")]
+    [TouchPortalActionText("0", -100, 100)]
     [TouchPortalActionMapping("RUDDER_TRIM_SET")]
     public static object RudderTrimSet { get; }
 

--- a/MSFSTouchPortalPlugin/Objects/InstrumentsSystems/Communication.cs
+++ b/MSFSTouchPortalPlugin/Objects/InstrumentsSystems/Communication.cs
@@ -3,14 +3,44 @@ using MSFSTouchPortalPlugin.Constants;
 using MSFSTouchPortalPlugin.Enums;
 using TouchPortalExtension.Attributes;
 
-namespace MSFSTouchPortalPlugin.Objects.InstrumentsSystems {
+namespace MSFSTouchPortalPlugin.Objects.InstrumentsSystems 
+{
   [SimVarDataRequestGroup]
+  [SimNotificationGroup(Groups.Communication)]
   [TouchPortalCategory("Communication", "MSFS - Communication")]
   internal static class CommunicationMapping {
 
     [TouchPortalAction("Radios", "Radio Interaction", "MSFS", "Radio Interaction", "Radio {0} - {1}", true)]
-    [TouchPortalActionChoice(new [] { "COM1", "COM2", "NAV1", "NAV2" }, "COM1")]
-    [TouchPortalActionChoice(new [] { "Increase 25 KHz", "Increase 1 MHz", "Increase 25 KHz w/ Carry Digits", "Decrease 25 KHz", "Decrease 1Mhz", "Decrease 25 KHz w/ Carry Digits", "Standby Swap" }, "Increase 25 KHz")]
+    [TouchPortalActionChoice(new [] { "COM1", "COM2", "NAV1", "NAV2" })]
+    [TouchPortalActionChoice(new [] { "Increase 25 KHz", "Increase 1 MHz", "Increase 25 KHz w/ Carry Digits", "Decrease 25 KHz", "Decrease 1Mhz", "Decrease 25 KHz w/ Carry Digits", "Standby Swap" })]
+    [TouchPortalActionMapping("COM_STBY_RADIO_SWAP",        new[] { "COM1", "Standby Swap" })]
+    [TouchPortalActionMapping("COM_RADIO_WHOLE_DEC",        new[] { "COM1", "Decrease 1Mhz" })]
+    [TouchPortalActionMapping("COM_RADIO_WHOLE_INC",        new[] { "COM1", "Increase 1 MHz" })]
+    [TouchPortalActionMapping("COM_RADIO_FRACT_DEC",        new[] { "COM1", "Decrease 25 KHz" })]
+    [TouchPortalActionMapping("COM_RADIO_FRACT_DEC_CARRY",  new[] { "COM1", "Decrease 25 KHz w/ Carry Digits" })]
+    [TouchPortalActionMapping("COM_RADIO_FRACT_INC",        new[] { "COM1", "Increase 25 KHz" })]
+    [TouchPortalActionMapping("COM_RADIO_FRACT_INC_CARRY",  new[] { "COM1", "Increase 25 KHz w/ Carry Digits" })]
+    [TouchPortalActionMapping("COM2_RADIO_SWAP",            new[] { "COM2", "Standby Swap" })]
+    [TouchPortalActionMapping("COM2_RADIO_WHOLE_DEC",       new[] { "COM2", "Decrease 1Mhz" })]
+    [TouchPortalActionMapping("COM2_RADIO_WHOLE_INC",       new[] { "COM2", "Increase 1 MHz" })]
+    [TouchPortalActionMapping("COM2_RADIO_FRACT_DEC",       new[] { "COM2", "Decrease 25 KHz" })]
+    [TouchPortalActionMapping("COM2_RADIO_FRACT_DEC_CARRY", new[] { "COM2", "Decrease 25 KHz w/ Carry Digits" })]
+    [TouchPortalActionMapping("COM2_RADIO_FRACT_INC",       new[] { "COM2", "Increase 25 KHz" })]
+    [TouchPortalActionMapping("COM2_RADIO_FRACT_INC_CARRY", new[] { "COM2", "Increase 25 KHz w/ Carry Digits" })]
+    [TouchPortalActionMapping("NAV1_RADIO_SWAP",            new[] { "NAV1", "Standby Swap" })]
+    [TouchPortalActionMapping("NAV1_RADIO_WHOLE_DEC",       new[] { "NAV1", "Decrease 1Mhz" })]
+    [TouchPortalActionMapping("NAV1_RADIO_WHOLE_INC",       new[] { "NAV1", "Increase 1 MHz" })]
+    [TouchPortalActionMapping("NAV1_RADIO_FRACT_DEC",       new[] { "NAV1", "Decrease 25 KHz" })]
+    [TouchPortalActionMapping("NAV1_RADIO_FRACT_DEC_CARRY", new[] { "NAV1", "Decrease 25 KHz w/ Carry Digits" })]
+    [TouchPortalActionMapping("NAV1_RADIO_FRACT_INC",       new[] { "NAV1", "Increase 25 KHz" })]
+    [TouchPortalActionMapping("NAV1_RADIO_FRACT_INC_CARRY", new[] { "NAV1", "Increase 25 KHz w/ Carry Digits" })]
+    [TouchPortalActionMapping("NAV2_RADIO_SWAP",            new[] { "NAV2", "Standby Swap" })]
+    [TouchPortalActionMapping("NAV2_RADIO_WHOLE_DEC",       new[] { "NAV2", "Decrease 1Mhz" })]
+    [TouchPortalActionMapping("NAV2_RADIO_WHOLE_INC",       new[] { "NAV2", "Increase 1 MHz" })]
+    [TouchPortalActionMapping("NAV2_RADIO_FRACT_DEC",       new[] { "NAV2", "Decrease 25 KHz" })]
+    [TouchPortalActionMapping("NAV2_RADIO_FRACT_DEC_CARRY", new[] { "NAV2", "Decrease 25 KHz w/ Carry Digits" })]
+    [TouchPortalActionMapping("NAV2_RADIO_FRACT_INC",       new[] { "NAV2", "Increase 25 KHz" })]
+    [TouchPortalActionMapping("NAV2_RADIO_FRACT_INC_CARRY", new[] { "NAV2", "Increase 25 KHz w/ Carry Digits" })]
     public static object Radios { get; }
 
     [SimVarDataRequest]
@@ -54,112 +84,15 @@ namespace MSFSTouchPortalPlugin.Objects.InstrumentsSystems {
       new SimVarItem { Def = Definition.Nav2StandbyFrequency, SimVarName = "NAV STANDBY FREQUENCY:2", Unit = Units.MHz, CanSet = false, StringFormat = "{0:0.000#}" };
   }
 
-  [SimNotificationGroup(Groups.Communication)]
-  [TouchPortalCategoryMapping("Communication")]
-  internal enum Communication {
-    // Placeholder to offset each enum for SimConnect
-    Init = 10000,
+/*
+  COM_RADIO_SET,
+  COM_STBY_RADIO_SET,
+  COM2_RADIO_SET,
+  COM2_STBY_RADIO_SET,
+  NAV1_RADIO_SET,
+  NAV1_STBY_SET,
+  NAV2_RADIO_SET,
+  NAV2_STBY_SET,
+*/
 
-    #region Radios
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("Radios", new [] { "COM1", "Standby Swap" })]
-    COM_STBY_RADIO_SWAP,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Radios", new [] { "COM1", "Decrease 1Mhz" })]
-    COM_RADIO_WHOLE_DEC,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Radios", new [] { "COM1", "Increase 1 MHz" })]
-    COM_RADIO_WHOLE_INC,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Radios", new [] { "COM1", "Decrease 25 KHz" })]
-    COM_RADIO_FRACT_DEC,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Radios", new [] { "COM1", "Decrease 25 KHz w/ Carry Digits" })]
-    COM_RADIO_FRACT_DEC_CARRY,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Radios", new [] { "COM1", "Increase 25 KHz" })]
-    COM_RADIO_FRACT_INC,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Radios", new [] { "COM1", "Increase 25 KHz w/ Carry Digits" })]
-    COM_RADIO_FRACT_INC_CARRY,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("Radios", new [] { "COM2", "Standby Swap" })]
-    COM2_RADIO_SWAP,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Radios", new [] { "COM2", "Decrease 1Mhz" })]
-    COM2_RADIO_WHOLE_DEC,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Radios", new [] { "COM2", "Increase 1 MHz" })]
-    COM2_RADIO_WHOLE_INC,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Radios", new [] { "COM2", "Decrease 25 KHz" })]
-    COM2_RADIO_FRACT_DEC,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Radios", new [] { "COM2", "Decrease 25 KHz w/ Carry Digits" })]
-    COM2_RADIO_FRACT_DEC_CARRY,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Radios", new [] { "COM2", "Increase 25 KHz" })]
-    COM2_RADIO_FRACT_INC,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Radios", new [] { "COM2", "Increase 25 KHz w/ Carry Digits" })]
-    COM2_RADIO_FRACT_INC_CARRY,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("Radios", new [] { "NAV1", "Standby Swap" })]
-    NAV1_RADIO_SWAP,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Radios", new [] { "NAV1", "Decrease 1Mhz" })]
-    NAV1_RADIO_WHOLE_DEC,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Radios", new [] { "NAV1", "Increase 1 MHz" })]
-    NAV1_RADIO_WHOLE_INC,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Radios", new [] { "NAV1", "Decrease 25 KHz" })]
-    NAV1_RADIO_FRACT_DEC,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Radios", new [] { "NAV1", "Decrease 25 KHz w/ Carry Digits" })]
-    NAV1_RADIO_FRACT_DEC_CARRY,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Radios", new [] { "NAV1", "Increase 25 KHz" })]
-    NAV1_RADIO_FRACT_INC,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Radios", new [] { "NAV1", "Increase 25 KHz w/ Carry Digits" })]
-    NAV1_RADIO_FRACT_INC_CARRY,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("Radios", new [] { "NAV2", "Standby Swap" })]
-    NAV2_RADIO_SWAP,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Radios", new [] { "NAV2", "Decrease 1Mhz" })]
-    NAV2_RADIO_WHOLE_DEC,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Radios", new [] { "NAV2", "Increase 1 MHz" })]
-    NAV2_RADIO_WHOLE_INC,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Radios", new [] { "NAV2", "Decrease 25 KHz" })]
-    NAV2_RADIO_FRACT_DEC,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Radios", new [] { "NAV2", "Decrease 25 KHz w/ Carry Digits" })]
-    NAV2_RADIO_FRACT_DEC_CARRY,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Radios", new [] { "NAV2", "Increase 25 KHz" })]
-    NAV2_RADIO_FRACT_INC,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Radios", new [] { "NAV2", "Increase 25 KHz w/ Carry Digits" })]
-    NAV2_RADIO_FRACT_INC_CARRY,
-
-    COM_RADIO_SET,
-    COM_STBY_RADIO_SET,
-    COM2_RADIO_SET,
-    COM2_STBY_RADIO_SET,
-    NAV1_RADIO_SET,
-    NAV1_STBY_SET,
-    NAV2_RADIO_SET,
-    NAV2_STBY_SET,
-
-
-    #endregion
-  }
 }

--- a/MSFSTouchPortalPlugin/Objects/InstrumentsSystems/Electrical.cs
+++ b/MSFSTouchPortalPlugin/Objects/InstrumentsSystems/Electrical.cs
@@ -3,14 +3,17 @@ using MSFSTouchPortalPlugin.Constants;
 using MSFSTouchPortalPlugin.Enums;
 using TouchPortalExtension.Attributes;
 
-namespace MSFSTouchPortalPlugin.Objects.InstrumentsSystems {
+namespace MSFSTouchPortalPlugin.Objects.InstrumentsSystems
+{
   [SimVarDataRequestGroup]
+  [SimNotificationGroup(Groups.Electrical)]
   [TouchPortalCategory("Electrical", "MSFS - Electrical")]
   internal static class ElectricalMapping {
     #region Avionics
 
     [SimVarDataRequest]
     [TouchPortalAction("AvionicsMasterSwitch", "Avionics Master", "MSFS", "Toggle Avionics Master", "Toggle Avionics Master")]
+    [TouchPortalActionMapping("TOGGLE_AVIONICS_MASTER")]
     [TouchPortalState("AvionicsMasterSwitch", "text", "Avionics Master Switch", "")]
     public static readonly SimVarItem TOGGLE_AVIONICS_MASTER = new SimVarItem { Def = Definition.AvionicsMasterSwitch, SimVarName = "AVIONICS MASTER SWITCH", Unit = Units.Bool, CanSet = false };
 
@@ -20,41 +23,65 @@ namespace MSFSTouchPortalPlugin.Objects.InstrumentsSystems {
 
     [SimVarDataRequest]
     [TouchPortalAction("MasterAlternator", "Master Alternator", "MSFS", "Toggle Master Alternator", "Toggle Master Alternator")]
+    [TouchPortalActionMapping("TOGGLE_MASTER_ALTERNATOR")]
     [TouchPortalState("MasterAlternator", "text", "Master Alternator Status", "")]
     public static readonly SimVarItem MASTER_ALTERNATOR =
       new SimVarItem { Def = Definition.MasterAlternator, SimVarName = "GENERAL ENG MASTER ALTERNATOR:1", Unit = Units.Bool, CanSet = false };
 
     [SimVarDataRequest]
     [TouchPortalAction("MasterBattery", "Master Battery", "MSFS", "Toggle Master Battery", "Toggle Master Battery")]
+    [TouchPortalActionMapping("TOGGLE_MASTER_BATTERY")]
     [TouchPortalState("MasterBattery", "text", "Master Battery Status", "")]
     public static readonly SimVarItem MASTER_BATTERY =
       new SimVarItem { Def = Definition.MasterBattery, SimVarName = "ELECTRICAL MASTER BATTERY", Unit = Units.Bool, CanSet = false };
 
     [TouchPortalAction("MasterBatteryAlternator", "Master Battery & Alternator", "MSFS", "Toggle Master Battery & Alternator", "Toggle Master Battery & Alternator")]
+    [TouchPortalActionMapping("TOGGLE_MASTER_BATTERY_ALTERNATOR")]
     public static object MASTER_BATTERY_ALTERNATOR { get; }
 
     [TouchPortalAction("AlternatorIndex", "Alternator - Specific", "MSFS", "Toggle Specific Alternator", "Toggle Altenator - {0}")]
-    [TouchPortalActionChoice(new[] { "1", "2", "3", "4" }, "1")]
+    [TouchPortalActionChoice(new[] { "1", "2", "3", "4" })]
+    [TouchPortalActionMapping("TOGGLE_ALTERNATOR1", "1")]
+    [TouchPortalActionMapping("TOGGLE_ALTERNATOR2", "2")]
+    [TouchPortalActionMapping("TOGGLE_ALTERNATOR3", "3")]
+    [TouchPortalActionMapping("TOGGLE_ALTERNATOR4", "4")]
     public static object ALTERNATOR_INDEX { get; }
 
     #endregion
 
     #region Lights
 
-    [TouchPortalAction("StrobeLights", "Toggle/On/Off/Set Strobe Lights", "MSFS", "Toggle/On/Off/Set Strobe Lights", "Strobe Lights - {0}")]
-    [TouchPortalActionChoice(new[] { "Toggle", "On", "Off", "Set" }, "Toggle")]
+    [TouchPortalAction("StrobeLights", "Toggle/On/Off Strobe Lights", "MSFS", "Toggle/On/Off Strobe Lights", "Strobe Lights - {0}")]
+    [TouchPortalActionChoice(new[] { "Toggle", "On", "Off" })]
+    [TouchPortalActionMapping("STROBES_TOGGLE", "Toggle")]
+    [TouchPortalActionMapping("STROBES_ON", "On")]
+    [TouchPortalActionMapping("STROBES_OFF", "Off")]
     public static object STROBE_LIGHTS { get; }
 
-    [TouchPortalAction("PanelLights", "Toggle/On/Off/Set Panel Lights", "MSFS", "Toggle/On/Off/Set Panel Lights", "Panel Lights - {0}")]
-    [TouchPortalActionChoice(new[] { "Toggle", "On", "Off", "Set" }, "Toggle")]
+    [TouchPortalAction("PanelLights", "Toggle/On/Off Panel Lights", "MSFS", "Toggle/On/Off Panel Lights", "Panel Lights - {0}")]
+    [TouchPortalActionChoice(new[] { "Toggle", "On", "Off" })]
+    [TouchPortalActionMapping("PANEL_LIGHTS_TOGGLE", "Toggle")]
+    [TouchPortalActionMapping("PANEL_LIGHTS_ON", "On")]
+    [TouchPortalActionMapping("PANEL_LIGHTS_OFF", "Off")]
     public static object PANEL_LIGHTS { get; }
 
-    [TouchPortalAction("LandingLights", "Toggle/On/Off/Set Landing Lights", "MSFS", "Toggle/On/Off/Set Landing Lights", "Landing Lights - {0}")]
-    [TouchPortalActionChoice(new[] { "Toggle", "On", "Off", "Set" }, "Toggle")]
+    [TouchPortalAction("LandingLights", "Toggle/On/Off Landing Lights", "MSFS", "Toggle/On/Off Landing Lights", "Landing Lights - {0}")]
+    [TouchPortalActionChoice(new[] { "Toggle", "On", "Off" })]
+    [TouchPortalActionMapping("LANDING_LIGHTS_TOGGLE", "Toggle")]
+    [TouchPortalActionMapping("LANDING_LIGHTS_ON", "On")]
+    [TouchPortalActionMapping("LANDING_LIGHTS_OFF", "Off")]
     public static object LANDING_LIGHTS { get; }
 
     [TouchPortalAction("ToggleLights", "Toggle All/Specific Lights", "MSFS", "Toggle All/Specific Lights", "Toggle Lights - {0}")]
-    [TouchPortalActionChoice(new[] { "All", "Beacon", "Taxi", "Logo", "Recognition", "Wing", "Nav", "Cabin" }, "All")]
+    [TouchPortalActionChoice(new[] { "All", "Beacon", "Taxi", "Logo", "Recognition", "Wing", "Nav", "Cabin" })]
+    [TouchPortalActionMapping("ALL_LIGHTS_TOGGLE", "All")]
+    [TouchPortalActionMapping("TOGGLE_BEACON_LIGHTS", "Beacon")]
+    [TouchPortalActionMapping("TOGGLE_TAXI_LIGHTS", "Taxi")]
+    [TouchPortalActionMapping("TOGGLE_LOGO_LIGHTS", "Logo")]
+    [TouchPortalActionMapping("TOGGLE_RECOGNITION_LIGHTS", "Recognition")]
+    [TouchPortalActionMapping("TOGGLE_WING_LIGHTS", "Wing")]
+    [TouchPortalActionMapping("TOGGLE_NAV_LIGHTS", "Nav")]
+    [TouchPortalActionMapping("TOGGLE_CABIN_LIGHTS", "Cabin")]
     public static object ALL_LIGHTS { get; }
 
     [SimVarDataRequest]
@@ -96,120 +123,5 @@ namespace MSFSTouchPortalPlugin.Objects.InstrumentsSystems {
 
     #endregion
 
-  }
-
-  [SimNotificationGroup(Groups.Electrical)]
-  [TouchPortalCategoryMapping("Electrical")]
-  internal enum Electrical {
-    // Placeholder to offset each enum for SimConnect
-    Init = 6000,
-
-    #region Avionics
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("AvionicsMasterSwitch")]
-    TOGGLE_AVIONICS_MASTER,
-
-    #endregion
-
-    #region Alternator & Battery
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("MasterAlternator")]
-    TOGGLE_MASTER_ALTERNATOR,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("MasterBattery")]
-    TOGGLE_MASTER_BATTERY,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("MasterBatteryAlternator")]
-    TOGGLE_MASTER_BATTERY_ALTERNATOR,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("AlternatorIndex", "1")]
-    TOGGLE_ALTERNATOR1,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("AlternatorIndex", "2")]
-    TOGGLE_ALTERNATOR2,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("AlternatorIndex", "3")]
-    TOGGLE_ALTERNATOR3,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("AlternatorIndex", "4")]
-    TOGGLE_ALTERNATOR4,
-
-    #endregion
-
-    #region Lights
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("StrobeLights", "Toggle")]
-    STROBES_TOGGLE,
-    [SimActionEvent]
-    [TouchPortalActionMapping("StrobeLights", "On")]
-    STROBES_ON,
-    [SimActionEvent]
-    [TouchPortalActionMapping("StrobeLights", "Off")]
-    STROBES_OFF,
-    [SimActionEvent]
-    [TouchPortalActionMapping("StrobeLights", "Set")]
-    STROBES_SET,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("PanelLights", "Toggle")]
-    PANEL_LIGHTS_TOGGLE,
-    [SimActionEvent]
-    [TouchPortalActionMapping("PanelLights", "On")]
-    PANEL_LIGHTS_ON,
-    [SimActionEvent]
-    [TouchPortalActionMapping("PanelLights", "Off")]
-    PANEL_LIGHTS_OFF,
-    [SimActionEvent]
-    [TouchPortalActionMapping("PanelLights", "Set")]
-    PANEL_LIGHTS_SET,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("LandingLights", "Toggle")]
-    LANDING_LIGHTS_TOGGLE,
-    [SimActionEvent]
-    [TouchPortalActionMapping("LandingLights", "On")]
-    LANDING_LIGHTS_ON,
-    [SimActionEvent]
-    [TouchPortalActionMapping("LandingLights", "Off")]
-    LANDING_LIGHTS_OFF,
-    [SimActionEvent]
-    [TouchPortalActionMapping("LandingLights", "Set")]
-    LANDING_LIGHTS_SET,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("ToggleLights", "All")]
-    ALL_LIGHTS_TOGGLE,
-    [SimActionEvent]
-    [TouchPortalActionMapping("ToggleLights", "Beacon")]
-    TOGGLE_BEACON_LIGHTS,
-    [SimActionEvent]
-    [TouchPortalActionMapping("ToggleLights", "Taxi")]
-    TOGGLE_TAXI_LIGHTS,
-    [SimActionEvent]
-    [TouchPortalActionMapping("ToggleLights", "Logo")]
-    TOGGLE_LOGO_LIGHTS,
-    [SimActionEvent]
-    [TouchPortalActionMapping("ToggleLights", "Recognition")]
-    TOGGLE_RECOGNITION_LIGHTS,
-    [SimActionEvent]
-    [TouchPortalActionMapping("ToggleLights", "Wing")]
-    TOGGLE_WING_LIGHTS,
-    [SimActionEvent]
-    [TouchPortalActionMapping("ToggleLights", "Nav")]
-    TOGGLE_NAV_LIGHTS,
-    [SimActionEvent]
-    [TouchPortalActionMapping("ToggleLights", "Cabin")]
-    TOGGLE_CABIN_LIGHTS,
-
-    #endregion
   }
 }

--- a/MSFSTouchPortalPlugin/Objects/InstrumentsSystems/Engine.cs
+++ b/MSFSTouchPortalPlugin/Objects/InstrumentsSystems/Engine.cs
@@ -76,10 +76,11 @@ namespace MSFSTouchPortalPlugin.Objects.InstrumentsSystems
     [TouchPortalActionMapping("MAGNETO4_INCR", new[] { "4", "Increase" })]
     public static object MAGNETO_SPECIFIC { get; }
 
-    [TouchPortalAction("MagnetoSet", "Magnetos Set", "MSFS", "Set Magneto Switch Position", "Magneto Switch {0} to position {1}")]
-    [TouchPortalActionChoice(new[] { "All", "1", "2", "3", "4" })]
-    [TouchPortalActionNumeric(1, 1, 5)]
-    [TouchPortalActionMapping("MAGNETO_SET", "All")]
+    [TouchPortalAction("MagnetoSet", "Magnetos Set", "MSFS", "Set Magneto Switch Position", "Magneto Switch {0} to position {1} (0-4)")]
+    [TouchPortalActionChoice(new[] { "1", "2", "3", "4" })]
+    [TouchPortalActionNumeric(0, 0, 4)]
+    //[TouchPortalActionMapping("MAGNETO_SET", "All")]  // only value "1" works, same as MAGNETO_START
+    //[TouchPortalActionMapping("MAGNETO_SET_ACTUAL", "All")]  // Prepar3D
     [TouchPortalActionMapping("MAGNETO1_SET", "1")]
     [TouchPortalActionMapping("MAGNETO2_SET", "2")]
     [TouchPortalActionMapping("MAGNETO3_SET", "3")]
@@ -103,7 +104,7 @@ namespace MSFSTouchPortalPlugin.Objects.InstrumentsSystems
 
     #region Throttle
 
-    [TouchPortalAction("Throttle", "Throttle", "MSFS", "Sets all throttles", "All Throttles - {0}")]
+    [TouchPortalAction("Throttle", "Throttle", "MSFS", "Sets all throttles", "All Throttles - {0}", true)]
     [TouchPortalActionChoice(new [] { "Full", "Increase", "Increase Small", "Decrease", "Decrease Small", "Cut", "10%", "20%", "30%", "40%", "50%", "60%", "70%", "80%", "90%" })]
     [TouchPortalActionMapping("THROTTLE_FULL", "Full")]
     [TouchPortalActionMapping("THROTTLE_INCR", "Increase")]
@@ -133,9 +134,9 @@ namespace MSFSTouchPortalPlugin.Objects.InstrumentsSystems
     [TouchPortalActionMapping("THROTTLE1_CUT",        new[] { "1", "Cut" })]
     [TouchPortalActionMapping("THROTTLE2_FULL",       new[] { "2", "Full" })]
     [TouchPortalActionMapping("THROTTLE2_INCR",       new[] { "2", "Increase" })]
-    [TouchPortalActionMapping("THROTTLE2_INCR_SALL",  new[] { "2", "Increase Small" })]
+    [TouchPortalActionMapping("THROTTLE2_INCR_SMALL", new[] { "2", "Increase Small" })]
     [TouchPortalActionMapping("THROTTLE2_DECR",       new[] { "2", "Descrease" })]
-    [TouchPortalActionMapping("THROTTLE2_DECR_SALL",  new[] { "2", "Descrease Small" })]
+    [TouchPortalActionMapping("THROTTLE2_DECR_SMALL", new[] { "2", "Descrease Small" })]
     [TouchPortalActionMapping("THROTTLE2_CUT",        new[] { "2", "Cut" })]
     [TouchPortalActionMapping("THROTTLE3_FULL",       new[] { "3", "Full" })]
     [TouchPortalActionMapping("THROTTLE3_INCR",       new[] { "3", "Increase" })]
@@ -151,9 +152,9 @@ namespace MSFSTouchPortalPlugin.Objects.InstrumentsSystems
     [TouchPortalActionMapping("THROTTLE4_CUT",        new[] { "4", "Cut" })]
     public static object THROTTLE_SPECIFIC { get; }
 
-    [TouchPortalAction("ThrottleSet", "Throttle Set", "MSFS", "Sets all or specific Throttle(s) to specific value", "Set Throttle {0} to {1}%")]
+    [TouchPortalAction("ThrottleSet", "Throttle Set", "MSFS", "Sets all or specific Throttle(s) to specific value", "Set Throttle {0} to {1} (-16383 - +16383)")]
     [TouchPortalActionChoice(new[] { "All", "1", "2", "3", "4" }, "All")]
-    [TouchPortalActionText("0", 0, 100)]
+    [TouchPortalActionText("0", -16383, 16383)]
     [TouchPortalActionMapping("THROTTLE_SET",  new[] { "All" })]
     [TouchPortalActionMapping("THROTTLE1_SET", new[] { "1" })]
     [TouchPortalActionMapping("THROTTLE2_SET", new[] { "2" })]

--- a/MSFSTouchPortalPlugin/Objects/InstrumentsSystems/Engine.cs
+++ b/MSFSTouchPortalPlugin/Objects/InstrumentsSystems/Engine.cs
@@ -3,8 +3,10 @@ using MSFSTouchPortalPlugin.Constants;
 using MSFSTouchPortalPlugin.Enums;
 using TouchPortalExtension.Attributes;
 
-namespace MSFSTouchPortalPlugin.Objects.InstrumentsSystems {
+namespace MSFSTouchPortalPlugin.Objects.InstrumentsSystems
+{
   [SimVarDataRequestGroup]
+  [SimNotificationGroup(Groups.Engine)]
   [TouchPortalCategory("Engine", "MSFS - Engine")]
   internal static class EngineMapping {
 
@@ -12,11 +14,14 @@ namespace MSFSTouchPortalPlugin.Objects.InstrumentsSystems {
 
     [SimVarDataRequest]
     [TouchPortalAction("MasterIgnition", "Master Ignition Switch", "MSFS", "Toggle Master Ignition Switch", "Toggle Master Ignition Switch")]
+    [TouchPortalActionMapping("TOGGLE_MASTER_IGNITION_SWITCH")]
     [TouchPortalState("MasterIgnitionSwitch", "text", "Master Ignition Switch Status", "")]
     public static readonly SimVarItem MASTER_IGNITION = new SimVarItem { Def = Definition.MasterIgnitionSwitch, SimVarName = "MASTER IGNITION SWITCH", Unit = Units.Bool, CanSet = false };
 
     [TouchPortalAction("EngineAuto", "Engine Auto Start/Shutdown", "MSFS", "Start/Shutdown Engine", "Engine - {0}")]
     [TouchPortalActionChoice(new [] { "Start", "Shutdown" }, "Start")]
+    [TouchPortalActionMapping("ENGINE_AUTO_START", "Start")]
+    [TouchPortalActionMapping("ENGINE_AUTO_SHUTDOWN", "Shutdown")]
     public static object ENGINE_AUTO { get; }
 
     #endregion
@@ -24,13 +29,62 @@ namespace MSFSTouchPortalPlugin.Objects.InstrumentsSystems {
     #region Magneto
 
     [TouchPortalAction("AllMagenetos", "Toggle All Magnetos", "MSFS", "Toggle All Magnetos", "Toggle All Magnetos - {0}")]
-    [TouchPortalActionChoice(new [] { "Start", "Off", "Right", "Left", "Both", "Decrease", "Increase" }, "Start")]
+    [TouchPortalActionChoice(new [] { "Start", "Off", "Right", "Left", "Both", "Decrease", "Increase", "Select (for +/-)" })]
+    [TouchPortalActionMapping("MAGNETO_OFF", "Off")]
+    [TouchPortalActionMapping("MAGNETO_RIGHT", "Right")]
+    [TouchPortalActionMapping("MAGNETO_LEFT", "Left")]
+    [TouchPortalActionMapping("MAGNETO_BOTH", "Both")]
+    [TouchPortalActionMapping("MAGNETO_START", "Start")]
+    [TouchPortalActionMapping("MAGNETO_DECR", "Decrease")]
+    [TouchPortalActionMapping("MAGNETO_INCR", "Increase")]
+    [TouchPortalActionMapping("MAGNETO", "Select (for +/-)")]
     public static object ALL_MAGNETOS { get; }
 
     [TouchPortalAction("MagnetoSpecific", "Magnetos Specific", "MSFS", "Toggle Magneto Specific", "Toggle Magneto {0} - {1}")]
     [TouchPortalActionChoice(new [] { "1", "2", "3", "4" }, "1")]
     [TouchPortalActionChoice(new [] { "Start", "Off", "Right", "Left", "Both", "Decrease", "Increase" }, "Start")]
+    [TouchPortalActionMapping("MAGNETO1_OFF", new[] { "1", "Off" })]
+    [TouchPortalActionMapping("MAGNETO1_RIGHT", new[] { "1", "Right" })]
+    [TouchPortalActionMapping("MAGNETO1_LEFT", new[] { "1", "Left" })]
+    [TouchPortalActionMapping("MAGNETO1_BOTH", new[] { "1", "Both" })]
+    [TouchPortalActionMapping("MAGNETO1_START", new[] { "1", "Start" })]
+    [TouchPortalActionMapping("MAGNETO1_DECR", new[] { "1", "Decrease" })]
+    [TouchPortalActionMapping("MAGNETO1_INCR", new[] { "1", "Increase" })]
+
+    [TouchPortalActionMapping("MAGNETO2_OFF", new[] { "2", "Off" })]
+    [TouchPortalActionMapping("MAGNETO2_RIGHT", new[] { "2", "Right" })]
+    [TouchPortalActionMapping("MAGNETO2_LEFT", new[] { "2", "Left" })]
+    [TouchPortalActionMapping("MAGNETO2_BOTH", new[] { "2", "Both" })]
+    [TouchPortalActionMapping("MAGNETO2_START", new[] { "2", "Start" })]
+    [TouchPortalActionMapping("MAGNETO2_DECR", new[] { "2", "Decrease" })]
+    [TouchPortalActionMapping("MAGNETO2_INCR", new[] { "2", "Increase" })]
+
+    [TouchPortalActionMapping("MAGNETO3_OFF", new[] { "3", "Off" })]
+    [TouchPortalActionMapping("MAGNETO3_RIGHT", new[] { "3", "Right" })]
+    [TouchPortalActionMapping("MAGNETO3_LEFT", new[] { "3", "Left" })]
+    [TouchPortalActionMapping("MAGNETO3_BOTH", new[] { "3", "Both" })]
+    [TouchPortalActionMapping("MAGNETO3_START", new[] { "3", "Start" })]
+    [TouchPortalActionMapping("MAGNETO3_DECR", new[] { "3", "Decrease" })]
+    [TouchPortalActionMapping("MAGNETO3_INCR", new[] { "3", "Increase" })]
+
+    [TouchPortalActionMapping("MAGNETO4_OFF", new[] { "4", "Off" })]
+    [TouchPortalActionMapping("MAGNETO4_RIGHT", new[] { "4", "Right" })]
+    [TouchPortalActionMapping("MAGNETO4_LEFT", new[] { "4", "Left" })]
+    [TouchPortalActionMapping("MAGNETO4_BOTH", new[] { "4", "Both" })]
+    [TouchPortalActionMapping("MAGNETO4_START", new[] { "4", "Start" })]
+    [TouchPortalActionMapping("MAGNETO4_DECR", new[] { "4", "Decrease" })]
+    [TouchPortalActionMapping("MAGNETO4_INCR", new[] { "4", "Increase" })]
     public static object MAGNETO_SPECIFIC { get; }
+
+    [TouchPortalAction("MagnetoSet", "Magnetos Set", "MSFS", "Set Magneto Switch", "Magneto Switch {0} to {1}")]
+    [TouchPortalActionChoice(new[] { "All", "1", "2", "3", "4" })]
+    [TouchPortalActionNumeric(1, 1, 5)]
+    [TouchPortalActionMapping("MAGNETO_SET", "All")]
+    [TouchPortalActionMapping("MAGNETO1_SET", "1")]
+    [TouchPortalActionMapping("MAGNETO2_SET", "2")]
+    [TouchPortalActionMapping("MAGNETO3_SET", "3")]
+    [TouchPortalActionMapping("MAGNETO4_SET", "4")]
+    public static object MAGNETO_SET { get; }
 
     #endregion
 
@@ -38,6 +92,11 @@ namespace MSFSTouchPortalPlugin.Objects.InstrumentsSystems {
 
     [TouchPortalAction("Starters", "Toggle Starters", "MSFS", "Toggle Starters", "Toggle Starter - {0}")]
     [TouchPortalActionChoice(new [] { "All", "1", "2", "3", "4" }, "All")]
+    [TouchPortalActionMapping("TOGGLE_ALL_STARTERS", "All")]
+    [TouchPortalActionMapping("TOGGLE_STARTER1", "1")]
+    [TouchPortalActionMapping("TOGGLE_STARTER2", "2")]
+    [TouchPortalActionMapping("TOGGLE_STARTER3", "3")]
+    [TouchPortalActionMapping("TOGGLE_STARTER4", "4")]
     public static object STARTERS { get; }
 
     #endregion
@@ -45,13 +104,62 @@ namespace MSFSTouchPortalPlugin.Objects.InstrumentsSystems {
     #region Throttle
 
     [TouchPortalAction("Throttle", "Throttle", "MSFS", "Sets all throttles", "All Throttles - {0}")]
-    [TouchPortalActionChoice(new [] { "Full", "Increase", "Increase Small", "Decrease", "Decrease Small", "Cut", "Set", "10%", "20%", "30%", "40%", "50%", "60%", "70%", "80%", "90%" }, "Full")]
+    [TouchPortalActionChoice(new [] { "Full", "Increase", "Increase Small", "Decrease", "Decrease Small", "Cut", "10%", "20%", "30%", "40%", "50%", "60%", "70%", "80%", "90%" })]
+    [TouchPortalActionMapping("THROTTLE_FULL", "Full")]
+    [TouchPortalActionMapping("THROTTLE_INCR", "Increase")]
+    [TouchPortalActionMapping("THROTTLE_INCR_SMALL", "Increase Small")]
+    [TouchPortalActionMapping("THROTTLE_DECR", "Decrease")]
+    [TouchPortalActionMapping("THROTTLE_DECR_SMALL", "Decrease Small")]
+    [TouchPortalActionMapping("THROTTLE_CUT", "Cut")]
+    [TouchPortalActionMapping("THROTTLE_10", "10%")]
+    [TouchPortalActionMapping("THROTTLE_20", "20%")]
+    [TouchPortalActionMapping("THROTTLE_30", "30%")]
+    [TouchPortalActionMapping("THROTTLE_40", "40%")]
+    [TouchPortalActionMapping("THROTTLE_50", "50%")]
+    [TouchPortalActionMapping("THROTTLE_60", "60%")]
+    [TouchPortalActionMapping("THROTTLE_70", "70%")]
+    [TouchPortalActionMapping("THROTTLE_80", "80%")]
+    [TouchPortalActionMapping("THROTTLE_90", "90%")]
     public static object THROTTLE { get; }
 
     [TouchPortalAction("ThrottleSpecific", "Throttle Specific", "MSFS", "Sets Throttle on specific engine", "Throttle {0} - {1}", true)]
     [TouchPortalActionChoice(new [] { "1", "2", "3", "4" }, "1")]
-    [TouchPortalActionChoice(new [] { "Full", "Increase", "Increase Small", "Decrease", "Decrease Small", "Cut" }, "Full")]
+    [TouchPortalActionChoice(new [] { "Full", "Increase", "Increase Small", "Decrease", "Decrease Small", "Cut"})]
+    [TouchPortalActionMapping("THROTTLE1_FULL",       new[] { "1", "Full" })]
+    [TouchPortalActionMapping("THROTTLE1_INCR",       new[] { "1", "Increase" })]
+    [TouchPortalActionMapping("THROTTLE1_INCR_SMALL", new[] { "1", "Increase Small" })]
+    [TouchPortalActionMapping("THROTTLE1_DECR",       new[] { "1", "Descrease" })]
+    [TouchPortalActionMapping("THROTTLE1_DECR_SMALL", new[] { "1", "Descrease Small" })]
+    [TouchPortalActionMapping("THROTTLE1_CUT",        new[] { "1", "Cut" })]
+    [TouchPortalActionMapping("THROTTLE2_FULL",       new[] { "2", "Full" })]
+    [TouchPortalActionMapping("THROTTLE2_INCR",       new[] { "2", "Increase" })]
+    [TouchPortalActionMapping("THROTTLE2_INCR_SALL",  new[] { "2", "Increase Small" })]
+    [TouchPortalActionMapping("THROTTLE2_DECR",       new[] { "2", "Descrease" })]
+    [TouchPortalActionMapping("THROTTLE2_DECR_SALL",  new[] { "2", "Descrease Small" })]
+    [TouchPortalActionMapping("THROTTLE2_CUT",        new[] { "2", "Cut" })]
+    [TouchPortalActionMapping("THROTTLE3_FULL",       new[] { "3", "Full" })]
+    [TouchPortalActionMapping("THROTTLE3_INCR",       new[] { "3", "Increase" })]
+    [TouchPortalActionMapping("THROTTLE3_INCR_SMALL", new[] { "3", "Increase Small" })]
+    [TouchPortalActionMapping("THROTTLE3_DECR",       new[] { "3", "Descrease" })]
+    [TouchPortalActionMapping("THROTTLE3_DECR_SMALL", new[] { "3", "Descrease Small" })]
+    [TouchPortalActionMapping("THROTTLE3_CUT",        new[] { "3", "Cut" })]
+    [TouchPortalActionMapping("THROTTLE4_FULL",       new[] { "4", "Full" })]
+    [TouchPortalActionMapping("THROTTLE4_INCR",       new[] { "4", "Increase" })]
+    [TouchPortalActionMapping("THROTTLE4_INCR_SMALL", new[] { "4", "Increase Small" })]
+    [TouchPortalActionMapping("THROTTLE4_DECR",       new[] { "4", "Descrease" })]
+    [TouchPortalActionMapping("THROTTLE4_DECR_SMALL", new[] { "4", "Descrease Small" })]
+    [TouchPortalActionMapping("THROTTLE4_CUT",        new[] { "4", "Cut" })]
     public static object THROTTLE_SPECIFIC { get; }
+
+    [TouchPortalAction("ThrottleSet", "Throttle Set", "MSFS", "Sets all or specific Throttle(s) to specific value", "Set Throttle {0} to {1}")]
+    [TouchPortalActionChoice(new[] { "All", "1", "2", "3", "4" }, "All")]
+    [TouchPortalActionText("0", 0, 100)]
+    [TouchPortalActionMapping("THROTTLE_SET",  new[] { "All" })]
+    [TouchPortalActionMapping("THROTTLE1_SET", new[] { "1" })]
+    [TouchPortalActionMapping("THROTTLE2_SET", new[] { "2" })]
+    [TouchPortalActionMapping("THROTTLE3_SET", new[] { "3" })]
+    [TouchPortalActionMapping("THROTTLE4_SET", new[] { "4" })]
+    public static object THROTTLE_SET { get; }
 
 
     [SimVarDataRequest]
@@ -75,12 +183,46 @@ namespace MSFSTouchPortalPlugin.Objects.InstrumentsSystems {
     #region Mixture
 
     [TouchPortalAction("Mixture", "Mixture", "MSFS", "Sets all mixtures", "All Mixtures - {0}", true)]
-    [TouchPortalActionChoice(new [] { "Rich", "Increase", "Increase Small", "Decrease", "Decrease Small", "Lean", "Best", "Set" }, "Rich")]
+    [TouchPortalActionChoice(new [] { "Rich", "Increase", "Increase Small", "Decrease", "Decrease Small", "Lean", "Best"})]
+    [TouchPortalActionMapping("MIXTURE_RICH", "Rich")]
+    [TouchPortalActionMapping("MIXTURE_INCR", "Increase")]
+    [TouchPortalActionMapping("MIXTURE_INCR_SMALL", "Increase Small")]
+    [TouchPortalActionMapping("MIXTURE_DECR", "Decrease")]
+    [TouchPortalActionMapping("MIXTURE_DECR_SMALL", "Decrease Small")]
+    [TouchPortalActionMapping("MIXTURE_LEAN", "Lean")]
+    [TouchPortalActionMapping("MIXTURE_SET_BEST", "Best")]
     public static object MIXTURE { get; }
 
     [TouchPortalAction("MixtureSpecific", "Mixture Specific", "MSFS", "Sets mixture on specific engine", "Mixture {0} - {1}", true)]
     [TouchPortalActionChoice(new [] { "1", "2", "3", "4" }, "1")]
-    [TouchPortalActionChoice(new [] { "Rich", "Increase", "Increase Small", "Decrease", "Decrease Small", "Lean" }, "Rich")]
+    [TouchPortalActionChoice(new [] { "Rich", "Increase", "Increase Small", "Decrease", "Decrease Small", "Lean" })]
+    [TouchPortalActionMapping("MIXTURE1_RICH", new[] { "1", "Rich" })]
+    [TouchPortalActionMapping("MIXTURE1_INCR", new[] { "1", "Increase" })]
+    [TouchPortalActionMapping("MIXTURE1_INCR_SMALL", new[] { "1", "Increase Small" })]
+    [TouchPortalActionMapping("MIXTURE1_DECR", new[] { "1", "Decrease" })]
+    [TouchPortalActionMapping("MIXTURE1_DECR_SMALL", new[] { "1", "Decrease Small" })]
+    [TouchPortalActionMapping("MIXTURE1_LEAN", new[] { "1", "Lean" })]
+
+    [TouchPortalActionMapping("MIXTURE2_RICH", new[] { "2", "Rich" })]
+    [TouchPortalActionMapping("MIXTURE2_INCR", new[] { "2", "Increase" })]
+    [TouchPortalActionMapping("MIXTURE2_INCR_SMALL", new[] { "2", "Increase Small" })]
+    [TouchPortalActionMapping("MIXTURE2_DECR", new[] { "2", "Decrease" })]
+    [TouchPortalActionMapping("MIXTURE2_DECR_SMALL", new[] { "2", "Decrease Small" })]
+    [TouchPortalActionMapping("MIXTURE2_LEAN", new[] { "2", "Lean" })]
+
+    [TouchPortalActionMapping("MIXTURE3_RICH", new[] { "3", "Rich" })]
+    [TouchPortalActionMapping("MIXTURE3_INCR", new[] { "3", "Increase" })]
+    [TouchPortalActionMapping("MIXTURE3_INCR_SMALL", new[] { "3", "Increase Small" })]
+    [TouchPortalActionMapping("MIXTURE3_DECR", new[] { "3", "Decrease" })]
+    [TouchPortalActionMapping("MIXTURE3_DECR_SMALL", new[] { "3", "Decrease Small" })]
+    [TouchPortalActionMapping("MIXTURE3_LEAN", new[] { "3", "Lean" })]
+
+    [TouchPortalActionMapping("MIXTURE4_RICH", new[] { "4", "Rich" })]
+    [TouchPortalActionMapping("MIXTURE4_INCR", new[] { "4", "Increase" })]
+    [TouchPortalActionMapping("MIXTURE4_INCR_SMALL", new[] { "4", "Increase Small" })]
+    [TouchPortalActionMapping("MIXTURE4_DECR", new[] { "4", "Decrease" })]
+    [TouchPortalActionMapping("MIXTURE4_DECR_SMALL", new[] { "4", "Decrease Small" })]
+    [TouchPortalActionMapping("MIXTURE4_LEAN", new[] { "4", "Lean" })]
     public static object MIXTURE_SPECIFIC { get; }
 
     [SimVarDataRequest]
@@ -104,9 +246,58 @@ namespace MSFSTouchPortalPlugin.Objects.InstrumentsSystems {
     #region Propeller
 
     [TouchPortalAction("PropellerPitch", "Propeller Pitch", "MSFS", "Adjusts propeller pitch levers/feather", "Pitch {0} - {1}", true)]
-    [TouchPortalActionChoice(new[] {"All", "1", "2", "3", "4" }, "All")]
-    [TouchPortalActionChoice(new[] { "Increment", "Increment Small", "Decrement", "Decrement Small", "Min (hi pitch)", "Max (lo pitch)", "Toggle Feather Switch" }, "Increment")]
+    [TouchPortalActionChoice(new[] {"All", "1", "2", "3", "4" })]
+    [TouchPortalActionChoice(new[] { "Increment", "Increment Small", "Decrement", "Decrement Small", "Min (hi pitch)", "Max (lo pitch)", "Toggle Feather Switch" })]
+    [TouchPortalActionMapping("PROP_PITCH_INCR", new[] { "All", "Increment" })]
+    [TouchPortalActionMapping("PROP_PITCH_INCR_SMALL", new[] { "All", "Increment Small" })]
+    [TouchPortalActionMapping("PROP_PITCH_DECR", new[] { "All", "Decrement" })]
+    [TouchPortalActionMapping("PROP_PITCH_DECR_SMALL", new[] { "All", "Decrement Small" })]
+    [TouchPortalActionMapping("PROP_PITCH_HI", new[] { "All", "Min (hi pitch)" })]
+    [TouchPortalActionMapping("PROP_PITCH_LO", new[] { "All", "Max (lo pitch)" })]
+    [TouchPortalActionMapping("TOGGLE_FEATHER_SWITCHES", new[] { "All", "Toggle Feather Switch" })]
+
+    [TouchPortalActionMapping("PROP_PITCH1_INCR", new[] { "1", "Increment" })]
+    [TouchPortalActionMapping("PROP_PITCH1_INCR_SMALL", new[] { "1", "Increment Small" })]
+    [TouchPortalActionMapping("PROP_PITCH1_DECR", new[] { "1", "Decrement" })]
+    [TouchPortalActionMapping("PROP_PITCH1_DECR_SMALL", new[] { "1", "Decrement Small" })]
+    [TouchPortalActionMapping("PROP_PITCH1_HI", new[] { "1", "Min (hi pitch)" })]
+    [TouchPortalActionMapping("PROP_PITCH1_LO", new[] { "1", "Max (lo pitch)" })]
+    [TouchPortalActionMapping("TOGGLE_FEATHER_SWITCH_1", new[] { "1", "Toggle Feather Switch" })]
+
+    [TouchPortalActionMapping("PROP_PITCH2_INCR", new[] { "2", "Increment" })]
+    [TouchPortalActionMapping("PROP_PITCH2_INCR_SMALL", new[] { "2", "Increment Small" })]
+    [TouchPortalActionMapping("PROP_PITCH2_DECR", new[] { "2", "Decrement" })]
+    [TouchPortalActionMapping("PROP_PITCH2_DECR_SMALL", new[] { "2", "Decrement Small" })]
+    [TouchPortalActionMapping("PROP_PITCH2_HI", new[] { "2", "Min (hi pitch)" })]
+    [TouchPortalActionMapping("PROP_PITCH2_LO", new[] { "2", "Max (lo pitch)" })]
+    [TouchPortalActionMapping("TOGGLE_FEATHER_SWITCH_2", new[] { "2", "Toggle Feather Switch" })]
+
+    [TouchPortalActionMapping("PROP_PITCH3_INCR", new[] { "3", "Increment" })]
+    [TouchPortalActionMapping("PROP_PITCH3_INCR_SMALL", new[] { "3", "Increment Small" })]
+    [TouchPortalActionMapping("PROP_PITCH3_DECR", new[] { "3", "Decrement" })]
+    [TouchPortalActionMapping("PROP_PITCH3_DECR_SMALL", new[] { "3", "Decrement Small" })]
+    [TouchPortalActionMapping("PROP_PITCH3_HI", new[] { "3", "Min (hi pitch)" })]
+    [TouchPortalActionMapping("PROP_PITCH3_LO", new[] { "3", "Max (lo pitch)" })]
+    [TouchPortalActionMapping("TOGGLE_FEATHER_SWITCH_3", new[] { "3", "Toggle Feather Switch" })]
+
+    [TouchPortalActionMapping("PROP_PITCH4_INCR", new[] { "4", "Increment" })]
+    [TouchPortalActionMapping("PROP_PITCH4_INCR_SMALL", new[] { "4", "Increment Small" })]
+    [TouchPortalActionMapping("PROP_PITCH4_DECR", new[] { "4", "Decrement" })]
+    [TouchPortalActionMapping("PROP_PITCH4_DECR_SMALL", new[] { "4", "Decrement Small" })]
+    [TouchPortalActionMapping("PROP_PITCH4_HI", new[] { "4", "Min (hi pitch)" })]
+    [TouchPortalActionMapping("PROP_PITCH4_LO", new[] { "4", "Max (lo pitch)" })]
+    [TouchPortalActionMapping("TOGGLE_FEATHER_SWITCH_4", new[] { "4", "Toggle Feather Switch" })]
     public static object PROPELLER_PITCH { get; }
+
+    [TouchPortalAction("PropellerPitchSet", "Propeller Pitch Set", "MSFS", "Sets propeller pitch lever to value (0 to 16383)", "Swt Prop {0} Pitch to {1}")]
+    [TouchPortalActionChoice(new[] { "All", "1", "2", "3", "4" })]
+    [TouchPortalActionText("0", 0, 16383)]
+    [TouchPortalActionMapping("PROP_PITCH_SET", "All")]
+    [TouchPortalActionMapping("PROP_PITCH1_SET", "1")]
+    [TouchPortalActionMapping("PROP_PITCH2_SET", "2")]
+    [TouchPortalActionMapping("PROP_PITCH3_SET", "3")]
+    [TouchPortalActionMapping("PROP_PITCH4_SET", "4")]
+    public static object PROPELLER_PITCH_SET { get; }
 
     [SimVarDataRequest]
     [TouchPortalState("PropellerEngine1", "text", "Propeller - Engine 1 - Percentage", "")]
@@ -190,524 +381,4 @@ namespace MSFSTouchPortalPlugin.Objects.InstrumentsSystems {
     #endregion
   }
 
-  [SimNotificationGroup(Groups.Engine)]
-  [TouchPortalCategoryMapping("Engine")]
-  internal enum Engine {
-    // Placeholder to offset each enum for SimConnect
-    Init = 4000,
-
-    #region Ignition
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("MasterIgnition")]
-    TOGGLE_MASTER_IGNITION_SWITCH,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("EngineAuto", "Start")]
-    ENGINE_AUTO_START,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("EngineAuto", "Shutdown")]
-    ENGINE_AUTO_SHUTDOWN,
-
-    #endregion
-
-    #region Magneto
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("AllMagenetos", "Off")]
-    MAGNETO_OFF,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AllMagenetos", "Right")]
-    MAGNETO_RIGHT,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AllMagenetos", "Left")]
-    MAGNETO_LEFT,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AllMagenetos", "Both")]
-    MAGNETO_BOTH,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AllMagenetos", "Start")]
-    MAGNETO_START,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AllMagenetos", "Decrease")]
-    MAGNETO_DECR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AllMagenetos", "Increase")]
-    MAGNETO_INCR,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("MagnetoSpecific", new [] { "1", "Off" })]
-    MAGNETO1_OFF,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MagnetoSpecific", new [] { "1", "Right" })]
-    MAGNETO1_RIGHT,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MagnetoSpecific", new [] { "1", "Left" })]
-    MAGNETO1_LEFT,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MagnetoSpecific", new [] { "1", "Both" })]
-    MAGNETO1_BOTH,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MagnetoSpecific", new [] { "1", "Start" })]
-    MAGNETO1_START,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MagnetoSpecific", new [] { "1", "Decrease" })]
-    MAGNETO1_DECR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MagnetoSpecific", new [] { "1", "Increase" })]
-    MAGNETO1_INCR,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("MagnetoSpecific", new [] { "2", "Off" })]
-    MAGNETO2_OFF,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MagnetoSpecific", new [] { "2", "Right" })]
-    MAGNETO2_RIGHT,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MagnetoSpecific", new [] { "2", "Left" })]
-    MAGNETO2_LEFT,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MagnetoSpecific", new [] { "2", "Both" })]
-    MAGNETO2_BOTH,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MagnetoSpecific", new [] { "2", "Start" })]
-    MAGNETO2_START,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MagnetoSpecific", new [] { "2", "Decrease" })]
-    MAGNETO2_DECR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MagnetoSpecific", new [] { "2", "Increase" })]
-    MAGNETO2_INCR,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("MagnetoSpecific", new [] { "3", "Off" })]
-    MAGNETO3_OFF,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MagnetoSpecific", new [] { "3", "Right" })]
-    MAGNETO3_RIGHT,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MagnetoSpecific", new [] { "3", "Left" })]
-    MAGNETO3_LEFT,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MagnetoSpecific", new [] { "3", "Both" })]
-    MAGNETO3_BOTH,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MagnetoSpecific", new [] { "3", "Start" })]
-    MAGNETO3_START,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MagnetoSpecific", new [] { "3", "Decrease" })]
-    MAGNETO3_DECR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MagnetoSpecific", new [] { "3", "Increase" })]
-    MAGNETO3_INCR,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("MagnetoSpecific", new [] { "4", "Off" })]
-    MAGNETO4_OFF,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MagnetoSpecific", new [] { "4", "Right" })]
-    MAGNETO4_RIGHT,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MagnetoSpecific", new [] { "4", "Left" })]
-    MAGNETO4_LEFT,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MagnetoSpecific", new [] { "4", "Both" })]
-    MAGNETO4_BOTH,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MagnetoSpecific", new [] { "4", "Start" })]
-    MAGNETO4_START,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MagnetoSpecific", new [] { "4", "Decrease" })]
-    MAGNETO4_DECR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MagnetoSpecific", new [] { "4", "Increase" })]
-    MAGNETO4_INCR,
-
-    MAGNETO_SET,
-    MAGNETO1_SET,
-    MAGNETO2_SET,
-    MAGNETO3_SET,
-    MAGNETO4_SET,
-
-    #endregion
-
-    #region Starters
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("Starters", "All")]
-    TOGGLE_ALL_STARTERS,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Starters", "1")]
-    TOGGLE_STARTER1,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Starters", "2")]
-    TOGGLE_STARTER2,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Starters", "3")]
-    TOGGLE_STARTER3,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Starters", "4")]
-    TOGGLE_STARTER4,
-
-    #endregion
-
-    #region Throttle
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("Throttle", "Full")]
-    THROTTLE_FULL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Throttle", "Increase")]
-    THROTTLE_INCR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Throttle", "Increase Small")]
-    THROTTLE_INCR_SMALL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Throttle", "Decrease")]
-    THROTTLE_DECR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Throttle", "Decrease Small")]
-    THROTTLE_DECR_SMALL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Throttle", "Cut")]
-    THROTTLE_CUT,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Throttle", "Set")]
-    THROTTLE_SET,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Throttle", "10%")]
-    THROTTLE_10,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Throttle", "20%")]
-    THROTTLE_20,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Throttle", "30%")]
-    THROTTLE_30,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Throttle", "40%")]
-    THROTTLE_40,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Throttle", "50%")]
-    THROTTLE_50,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Throttle", "60%")]
-    THROTTLE_60,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Throttle", "70%")]
-    THROTTLE_70,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Throttle", "80%")]
-    THROTTLE_80,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Throttle", "90%")]
-    THROTTLE_90,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("ThrottleSpecific", new [] { "1", "Full" })]
-    THROTTLE1_FULL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("ThrottleSpecific", new [] { "1", "Increase" })]
-    THROTTLE1_INCR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("ThrottleSpecific", new [] { "1", "Increase Small" })]
-    THROTTLE1_INCR_SMALL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("ThrottleSpecific", new [] { "1", "Descrease" })]
-    THROTTLE1_DECR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("ThrottleSpecific", new [] { "1", "Descrease Small" })]
-    THROTTLE1_DECR_SMALL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("ThrottleSpecific", new [] { "1", "Cut" })]
-    THROTTLE1_CUT,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("ThrottleSpecific", new [] { "2", "Full" })]
-    THROTTLE2_FULL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("ThrottleSpecific", new [] { "2", "Increase" })]
-    THROTTLE2_INCR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("ThrottleSpecific", new [] { "2", "Increase Small" })]
-    THROTTLE2_INCR_SMALL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("ThrottleSpecific", new [] { "2", "Descrease" })]
-    THROTTLE2_DECR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("ThrottleSpecific", new [] { "2", "Descrease Small" })]
-    THROTTLE2_DECR_SMALL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("ThrottleSpecific", new [] { "2", "Cut" })]
-    THROTTLE2_CUT,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("ThrottleSpecific", new [] { "3", "Full" })]
-    THROTTLE3_FULL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("ThrottleSpecific", new [] { "3", "Increase" })]
-    THROTTLE3_INCR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("ThrottleSpecific", new [] { "3", "Increase Small" })]
-    THROTTLE3_INCR_SMALL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("ThrottleSpecific", new [] { "3", "Descrease" })]
-    THROTTLE3_DECR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("ThrottleSpecific", new [] { "3", "Descrease Small" })]
-    THROTTLE3_DECR_SMALL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("ThrottleSpecific", new [] { "3", "Cut" })]
-    THROTTLE3_CUT,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("ThrottleSpecific", new [] { "4", "Full" })]
-    THROTTLE4_FULL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("ThrottleSpecific", new [] { "4", "Increase" })]
-    THROTTLE4_INCR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("ThrottleSpecific", new [] { "4", "Increase Small" })]
-    THROTTLE4_INCR_SMALL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("ThrottleSpecific", new [] { "4", "Descrease" })]
-    THROTTLE4_DECR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("ThrottleSpecific", new [] { "4", "Descrease Small" })]
-    THROTTLE4_DECR_SMALL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("ThrottleSpecific", new [] { "4", "Cut" })]
-    THROTTLE4_CUT,
-
-    THROTTLE1_SET,
-    THROTTLE2_SET,
-    THROTTLE3_SET,
-    THROTTLE4_SET,
-
-    #endregion
-
-    #region Mixture
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("Mixture", "Set")]
-    MIXTURE_SET,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Mixture", "Rich")]
-    MIXTURE_RICH,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Mixture", "Increase")]
-    MIXTURE_INCR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Mixture", "Increase Small")]
-    MIXTURE_INCR_SMALL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Mixture", "Decrease")]
-    MIXTURE_DECR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Mixture", "Decrease Small")]
-    MIXTURE_DECR_SMALL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Mixture", "Lean")]
-    MIXTURE_LEAN,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Mixture", "Best")]
-    MIXTURE_SET_BEST,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("MixtureSpecific", new [] { "1", "Rich" })]
-    MIXTURE1_RICH,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MixtureSpecific", new [] { "1", "Increase" })]
-    MIXTURE1_INCR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MixtureSpecific", new [] { "1", "Increase Small" })]
-    MIXTURE1_INCR_SMALL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MixtureSpecific", new [] { "1", "Decrease" })]
-    MIXTURE1_DECR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MixtureSpecific", new [] { "1", "Decrease Small" })]
-    MIXTURE1_DECR_SMALL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MixtureSpecific", new [] { "1", "Lean" })]
-    MIXTURE1_LEAN,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("MixtureSpecific", new [] { "2", "Rich" })]
-    MIXTURE2_RICH,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MixtureSpecific", new [] { "2", "Increase" })]
-    MIXTURE2_INCR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MixtureSpecific", new [] { "2", "Increase Small" })]
-    MIXTURE2_INCR_SMALL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MixtureSpecific", new [] { "2", "Decrease" })]
-    MIXTURE2_DECR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MixtureSpecific", new [] { "2", "Decrease Small" })]
-    MIXTURE2_DECR_SMALL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MixtureSpecific", new [] { "2", "Lean" })]
-    MIXTURE2_LEAN,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("MixtureSpecific", new [] { "3", "Rich" })]
-    MIXTURE3_RICH,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MixtureSpecific", new [] { "3", "Increase" })]
-    MIXTURE3_INCR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MixtureSpecific", new [] { "3", "Increase Small" })]
-    MIXTURE3_INCR_SMALL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MixtureSpecific", new [] { "3", "Decrease" })]
-    MIXTURE3_DECR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MixtureSpecific", new [] { "3", "Decrease Small" })]
-    MIXTURE3_DECR_SMALL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MixtureSpecific", new [] { "3", "Lean" })]
-    MIXTURE3_LEAN,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("MixtureSpecific", new [] { "4", "Rich" })]
-    MIXTURE4_RICH,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MixtureSpecific", new [] { "4", "Increase" })]
-    MIXTURE4_INCR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MixtureSpecific", new [] { "4", "Increase Small" })]
-    MIXTURE4_INCR_SMALL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MixtureSpecific", new [] { "4", "Decrease" })]
-    MIXTURE4_DECR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MixtureSpecific", new [] { "4", "Decrease Small" })]
-    MIXTURE4_DECR_SMALL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("MixtureSpecific", new [] { "4", "Lean" })]
-    MIXTURE4_LEAN,
-
-    MIXTURE1_SET,
-    MIXTURE2_SET,
-    MIXTURE3_SET,
-    MIXTURE4_SET,
-
-    #endregion
-
-    #region Propeller
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("PropellerPitch", new[] { "All", "Increment" })]
-    PROP_PITCH_INCR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("PropellerPitch", new[] { "All", "Increment Small" })]
-    PROP_PITCH_INCR_SMALL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("PropellerPitch", new[] { "All", "Decrement" })]
-    PROP_PITCH_DECR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("PropellerPitch", new[] { "All", "Decrement Small" })]
-    PROP_PITCH_DECR_SMALL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("PropellerPitch", new[] { "All", "Min (hi pitch)" })]
-    PROP_PITCH_HI,
-    [SimActionEvent]
-    [TouchPortalActionMapping("PropellerPitch", new[] { "All", "Max (lo pitch)" })]
-    PROP_PITCH_LO,
-    [SimActionEvent]
-    [TouchPortalActionMapping("PropellerPitch", new[] { "All", "Toggle Feather Switch" })]
-    TOGGLE_FEATHER_SWITCHES,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("PropellerPitch", new[] { "1", "Increment" })]
-    PROP_PITCH1_INCR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("PropellerPitch", new[] { "1", "Increment Small" })]
-    PROP_PITCH1_INCR_SMALL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("PropellerPitch", new[] { "1", "Decrement" })]
-    PROP_PITCH1_DECR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("PropellerPitch", new[] { "1", "Decrement Small" })]
-    PROP_PITCH1_DECR_SMALL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("PropellerPitch", new[] { "1", "Min (hi pitch)" })]
-    PROP_PITCH1_HI,
-    [SimActionEvent]
-    [TouchPortalActionMapping("PropellerPitch", new[] { "1", "Max (lo pitch)" })]
-    PROP_PITCH1_LO,
-    [SimActionEvent]
-    [TouchPortalActionMapping("PropellerPitch", new[] { "1", "Toggle Feather Switch" })]
-    TOGGLE_FEATHER_SWITCH_1,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("PropellerPitch", new[] { "1", "Increment" })]
-    PROP_PITCH2_INCR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("PropellerPitch", new[] { "2", "Increment Small" })]
-    PROP_PITCH2_INCR_SMALL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("PropellerPitch", new[] { "2", "Decrement" })]
-    PROP_PITCH2_DECR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("PropellerPitch", new[] { "2", "Decrement Small" })]
-    PROP_PITCH2_DECR_SMALL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("PropellerPitch", new[] { "2", "Min (hi pitch)" })]
-    PROP_PITCH2_HI,
-    [SimActionEvent]
-    [TouchPortalActionMapping("PropellerPitch", new[] { "2", "Max (lo pitch)" })]
-    PROP_PITCH2_LO,
-    [SimActionEvent]
-    [TouchPortalActionMapping("PropellerPitch", new[] { "2", "Toggle Feather Switch" })]
-    TOGGLE_FEATHER_SWITCH_2,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("PropellerPitch", new[] { "3", "Increment" })]
-    PROP_PITCH3_INCR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("PropellerPitch", new[] { "3", "Increment Small" })]
-    PROP_PITCH3_INCR_SMALL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("PropellerPitch", new[] { "3", "Decrement" })]
-    PROP_PITCH3_DECR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("PropellerPitch", new[] { "3", "Decrement Small" })]
-    PROP_PITCH3_DECR_SMALL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("PropellerPitch", new[] { "3", "Min (hi pitch)" })]
-    PROP_PITCH3_HI,
-    [SimActionEvent]
-    [TouchPortalActionMapping("PropellerPitch", new[] { "3", "Max (lo pitch)" })]
-    PROP_PITCH3_LO,
-    [SimActionEvent]
-    [TouchPortalActionMapping("PropellerPitch", new[] { "3", "Toggle Feather Switch" })]
-    TOGGLE_FEATHER_SWITCH_3,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("PropellerPitch", new[] { "4", "Increment" })]
-    PROP_PITCH4_INCR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("PropellerPitch", new[] { "4", "Increment Small" })]
-    PROP_PITCH4_INCR_SMALL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("PropellerPitch", new[] { "4", "Decrement" })]
-    PROP_PITCH4_DECR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("PropellerPitch", new[] { "4", "Decrement Small" })]
-    PROP_PITCH4_DECR_SMALL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("PropellerPitch", new[] { "4", "Min (hi pitch)" })]
-    PROP_PITCH4_HI,
-    [SimActionEvent]
-    [TouchPortalActionMapping("PropellerPitch", new[] { "4", "Max (lo pitch)" })]
-    PROP_PITCH4_LO,
-    [SimActionEvent]
-    [TouchPortalActionMapping("PropellerPitch", new[] { "4", "Toggle Feather Switch" })]
-    TOGGLE_FEATHER_SWITCH_4,
-
-    #endregion
-  }
 }

--- a/MSFSTouchPortalPlugin/Objects/InstrumentsSystems/Engine.cs
+++ b/MSFSTouchPortalPlugin/Objects/InstrumentsSystems/Engine.cs
@@ -76,7 +76,7 @@ namespace MSFSTouchPortalPlugin.Objects.InstrumentsSystems
     [TouchPortalActionMapping("MAGNETO4_INCR", new[] { "4", "Increase" })]
     public static object MAGNETO_SPECIFIC { get; }
 
-    [TouchPortalAction("MagnetoSet", "Magnetos Set", "MSFS", "Set Magneto Switch", "Magneto Switch {0} to {1}")]
+    [TouchPortalAction("MagnetoSet", "Magnetos Set", "MSFS", "Set Magneto Switch Position", "Magneto Switch {0} to position {1}")]
     [TouchPortalActionChoice(new[] { "All", "1", "2", "3", "4" })]
     [TouchPortalActionNumeric(1, 1, 5)]
     [TouchPortalActionMapping("MAGNETO_SET", "All")]
@@ -151,7 +151,7 @@ namespace MSFSTouchPortalPlugin.Objects.InstrumentsSystems
     [TouchPortalActionMapping("THROTTLE4_CUT",        new[] { "4", "Cut" })]
     public static object THROTTLE_SPECIFIC { get; }
 
-    [TouchPortalAction("ThrottleSet", "Throttle Set", "MSFS", "Sets all or specific Throttle(s) to specific value", "Set Throttle {0} to {1}")]
+    [TouchPortalAction("ThrottleSet", "Throttle Set", "MSFS", "Sets all or specific Throttle(s) to specific value", "Set Throttle {0} to {1}%")]
     [TouchPortalActionChoice(new[] { "All", "1", "2", "3", "4" }, "All")]
     [TouchPortalActionText("0", 0, 100)]
     [TouchPortalActionMapping("THROTTLE_SET",  new[] { "All" })]
@@ -289,7 +289,7 @@ namespace MSFSTouchPortalPlugin.Objects.InstrumentsSystems
     [TouchPortalActionMapping("TOGGLE_FEATHER_SWITCH_4", new[] { "4", "Toggle Feather Switch" })]
     public static object PROPELLER_PITCH { get; }
 
-    [TouchPortalAction("PropellerPitchSet", "Propeller Pitch Set", "MSFS", "Sets propeller pitch lever to value (0 to 16383)", "Swt Prop {0} Pitch to {1}")]
+    [TouchPortalAction("PropellerPitchSet", "Propeller Pitch Set", "MSFS", "Sets propeller pitch lever to value", "Set Propeller {0} Pitch to {1} (0 to 16383)")]
     [TouchPortalActionChoice(new[] { "All", "1", "2", "3", "4" })]
     [TouchPortalActionText("0", 0, 16383)]
     [TouchPortalActionMapping("PROP_PITCH_SET", "All")]

--- a/MSFSTouchPortalPlugin/Objects/InstrumentsSystems/Environment.cs
+++ b/MSFSTouchPortalPlugin/Objects/InstrumentsSystems/Environment.cs
@@ -3,19 +3,36 @@ using MSFSTouchPortalPlugin.Constants;
 using MSFSTouchPortalPlugin.Enums;
 using TouchPortalExtension.Attributes;
 
-namespace MSFSTouchPortalPlugin.Objects.InstrumentsSystems {
+namespace MSFSTouchPortalPlugin.Objects.InstrumentsSystems
+{
   [SimVarDataRequestGroup]
+  [SimNotificationGroup(Groups.Environment)]
   [TouchPortalCategory("Environment", "MSFS - Environment")]
   internal static class EnvironmentMapping {
     #region Anti-Ice
 
     [TouchPortalAction("AntiIce", "Anti-Ice", "MSFS", "Toggle/On/Off Anti Ice", "Anti Ice - {0}")]
-    [TouchPortalActionChoice(new [] { "Toggle", "On", "Off", "Set" }, "Toggle")]
-    public static object ANTI_ICE { get; }
+    [TouchPortalActionChoice(new [] { "Toggle", "On", "Off" })]
+    [TouchPortalActionMapping("ANTI_ICE_TOGGLE", "Toggle")]
+    [TouchPortalActionMapping("ANTI_ICE_ON", "On")]
+    [TouchPortalActionMapping("ANTI_ICE_OFF", "Off")]
+    public static object AntiIce { get; }
 
-    [TouchPortalAction("AntiIceEng", "Anti-Ice Engine", "MSFS", "Toggle/On/Off Anti Ice Engine", "Anti Ice Engine {0} - {1}")]
-    [TouchPortalActionChoice(new[] { "1", "2", "3", "4" }, "1")]
-    [TouchPortalActionChoice(new [] { "Toggle","Set" }, "Toggle")]
+    [TouchPortalAction("AntiIceEng", "Anti-Ice Engine", "MSFS", "Toggle Anti Ice Engine", "Anti Ice Engine {0} Toggle")]
+    [TouchPortalActionChoice(new[] { "1", "2", "3", "4" })]
+    [TouchPortalActionMapping("ANTI_ICE_TOGGLE_ENG1", "1")]
+    [TouchPortalActionMapping("ANTI_ICE_TOGGLE_ENG2", "2")]
+    [TouchPortalActionMapping("ANTI_ICE_TOGGLE_ENG3", "3")]
+    [TouchPortalActionMapping("ANTI_ICE_TOGGLE_ENG4", "4")]
+    public static object AntiIceEng { get; }
+
+    [TouchPortalAction("AntiIceEngSet", "Anti-Ice Engine Set", "MSFS", "Set On/Off Anti Ice Engine", "Anti Ice Engine {0} - {1}")]
+    [TouchPortalActionChoice(new[] { "1", "2", "3", "4" })]
+    [TouchPortalActionSwitch()]
+    [TouchPortalActionMapping("ANTI_ICE_SET_ENG1", "1")]
+    [TouchPortalActionMapping("ANTI_ICE_SET_ENG2", "2")]
+    [TouchPortalActionMapping("ANTI_ICE_SET_ENG3", "3")]
+    [TouchPortalActionMapping("ANTI_ICE_SET_ENG4", "4")]
     public static object ANTI_ICE_ENGINE { get; }
 
     [SimVarDataRequest]
@@ -35,9 +52,11 @@ namespace MSFSTouchPortalPlugin.Objects.InstrumentsSystems {
     public static readonly SimVarItem AntiIceEng4 = new SimVarItem { Def = Definition.AntiIceEng4, SimVarName = "GENERAL ENG ANTI ICE POSITION:4", Unit = Units.Bool, CanSet = false };
 
     [TouchPortalAction("StructuralDeIce", "Structural De-ice", "MSFS", "Toggle Structural DeIce", "Toggle Structural DeIce")]
+    [TouchPortalActionMapping("TOGGLE_STRUCTURAL_DEICE")]
     public static object STRUCTURAL_DEICE { get; }
 
     [TouchPortalAction("PropellerDeIce", "Propeller De-ice", "MSFS", "Toggle Propeller DeIce", "Toggle Propeller DeIce")]
+    [TouchPortalActionMapping("TOGGLE_PROPELLER_DEICE")]
     public static object PROPELLER_DEICE { get; }
 
     [SimVarDataRequest]
@@ -71,7 +90,10 @@ namespace MSFSTouchPortalPlugin.Objects.InstrumentsSystems {
 
     [SimVarDataRequest]
     [TouchPortalAction("PitotHeat", "Pitot Heat", "MSFS", "Toggle/On/Off Pitot Heat", "Pitot Heat - {0}")]
-    [TouchPortalActionChoice(new [] { "Toggle", "On", "Off", "Set" }, "Toggle")]
+    [TouchPortalActionChoice(new [] { "Toggle", "On", "Off" })]
+    [TouchPortalActionMapping("PITOT_HEAT_TOGGLE", "Toggle")]
+    [TouchPortalActionMapping("PITOT_HEAT_ON", "On")]
+    [TouchPortalActionMapping("PITOT_HEAT_OFF", "Off")]
     [TouchPortalState("PitotHeat", "text", "Pitot Heat Status", "")]
     public static readonly SimVarItem PITOT_HEAT = new SimVarItem { Def = Definition.PitotHeat, SimVarName = "PITOT HEAT", Unit = Units.Bool, CanSet = false };
 
@@ -91,87 +113,6 @@ namespace MSFSTouchPortalPlugin.Objects.InstrumentsSystems {
     [TouchPortalState("PitotHeatSwitch4", "text", "Pitot Heat Switch 4 State (0=Off; 1=On; 2=Auto)", "")]
     public static readonly SimVarItem PitotHeatSwitch4 = new SimVarItem { Def = Definition.PitotHeatSwitch4, SimVarName = "PITOT HEAT SWITCH:4", Unit = Units.Enum, CanSet = false };
 
-    #endregion
-  }
-
-  [SimNotificationGroup(Groups.Environment)]
-  [TouchPortalCategoryMapping("Environment")]
-  internal enum Environment {
-    // Placeholder to offset each enum for SimConnect
-    Init = 5000,
-
-    #region Anti-Ice
-
-    // Anti-Ice
-    [SimActionEvent]
-    [TouchPortalActionMapping("AntiIce", "Toggle")]
-    ANTI_ICE_TOGGLE,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AntiIce", "On")]
-    ANTI_ICE_ON,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AntiIce", "Off")]
-    ANTI_ICE_OFF,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AntiIce", "Set")]
-    ANTI_ICE_SET,
-
-    // Anti-Ice Eng 1
-    [SimActionEvent]
-    [TouchPortalActionMapping("AntiIceEng", new[] { "1", "Toggle" })]
-    ANTI_ICE_TOGGLE_ENG1,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AntiIceEng", new[] { "1", "Set" })]
-    ANTI_ICE_SET_ENG1,
-
-    // Anti-Ice Eng 2
-    [SimActionEvent]
-    [TouchPortalActionMapping("AntiIceEng", new[] { "2", "Toggle" })]
-    ANTI_ICE_TOGGLE_ENG2,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AntiIceEng", new[] { "2", "Set" })]
-    ANTI_ICE_SET_ENG2,
-
-    // Anti-Ice Eng 3
-    [SimActionEvent]
-    [TouchPortalActionMapping("AntiIceEng", new[] { "3", "Toggle" })]
-    ANTI_ICE_TOGGLE_ENG3,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AntiIceEng", new[] { "3", "Set" })]
-    ANTI_ICE_SET_ENG3,
-
-    // Anti-Ice Eng 4
-    [SimActionEvent]
-    [TouchPortalActionMapping("AntiIceEng", new[] { "4", "Toggle" })]
-    ANTI_ICE_TOGGLE_ENG4,
-    [SimActionEvent]
-    [TouchPortalActionMapping("AntiIceEng", new[] { "4", "Set" })]
-    ANTI_ICE_SET_ENG4,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("StructuralDeIce")]
-    TOGGLE_STRUCTURAL_DEICE,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("PropellerDeIce")]
-    TOGGLE_PROPELLER_DEICE,
-
-    #endregion
-
-    #region Pitot Heat
-    // Pitot Heat
-    [SimActionEvent]
-    [TouchPortalActionMapping("PitotHeat", "Toggle")]
-    PITOT_HEAT_TOGGLE,
-    [SimActionEvent]
-    [TouchPortalActionMapping("PitotHeat", "On")]
-    PITOT_HEAT_ON,
-    [SimActionEvent]
-    [TouchPortalActionMapping("PitotHeat", "Off")]
-    PITOT_HEAT_OFF,
-    [SimActionEvent]
-    [TouchPortalActionMapping("PitotHeat", "Set")]
-    PITOT_HEAT_SET,
     #endregion
   }
 }

--- a/MSFSTouchPortalPlugin/Objects/InstrumentsSystems/FlightInstruments.cs
+++ b/MSFSTouchPortalPlugin/Objects/InstrumentsSystems/FlightInstruments.cs
@@ -1,10 +1,11 @@
 ﻿using MSFSTouchPortalPlugin.Attributes;
 using MSFSTouchPortalPlugin.Constants;
-using MSFSTouchPortalPlugin.Enums;
 using TouchPortalExtension.Attributes;
 
-namespace MSFSTouchPortalPlugin.Objects.InstrumentsSystems {
+namespace MSFSTouchPortalPlugin.Objects.InstrumentsSystems 
+{
   [SimVarDataRequestGroup]
+  //[SimNotificationGroup(Groups.FlightInstruments)]
   [TouchPortalCategory("FlightInstruments", "MSFS - Flight Instruments")]
   internal static class FlightInstrumentsMapping {
 
@@ -87,12 +88,5 @@ namespace MSFSTouchPortalPlugin.Objects.InstrumentsSystems {
 
     #endregion
 
-  }
-
-  [SimNotificationGroup(Groups.FlightInstruments)]
-  [TouchPortalCategoryMapping("FlightInstruments")]
-  internal enum FlightInstruments {
-    // Placeholder to offset each enum for SimConnect
-    Init = 8000,
   }
 }

--- a/MSFSTouchPortalPlugin/Objects/InstrumentsSystems/Fuel.cs
+++ b/MSFSTouchPortalPlugin/Objects/InstrumentsSystems/Fuel.cs
@@ -2,198 +2,111 @@
 using MSFSTouchPortalPlugin.Enums;
 using TouchPortalExtension.Attributes;
 
-namespace MSFSTouchPortalPlugin.Objects.InstrumentsSystems {
+namespace MSFSTouchPortalPlugin.Objects.InstrumentsSystems 
+{
   [SimVarDataRequestGroup]
+  [SimNotificationGroup(Groups.Fuel)]
   [TouchPortalCategory("InstrumentsSystems.Fuel", "MSFS - Fuel")]
   internal static class FuelMapping {
 
     [TouchPortalAction("AddFuel", "Add Fuel", "MSFS", "Adds 25% amount of Fuel", "Add 25% amount of fuel")]
+    [TouchPortalActionMapping("ADD_FUEL_QUANTITY")]
     public static object ADD_FUEL { get; }
 
     [TouchPortalAction("FuelSelectors", "Fuel Selectors", "MSFS", "Fuel Selectors", "Fuel Selector {0} - {1}")]
-    [TouchPortalActionChoice(new [] { "1", "2", "3", "4" }, "1")]
-    [TouchPortalActionChoice(new [] { "All", "Off", "Left", "Right", "Left - Main", "Right - Main", "Left - Aux", "Right - Aux", "Center" }, "All")]
+    [TouchPortalActionChoice(new [] { "1", "2", "3", "4" })]
+    [TouchPortalActionChoice(new [] { "All", "Off", "Left", "Right", "Left - Main", "Right - Main", "Left - Aux", "Right - Aux", "Center" })]
+    [TouchPortalActionMapping("FUEL_SELECTOR_OFF", new[] { "1", "Off" })]
+    [TouchPortalActionMapping("FUEL_SELECTOR_ALL", new[] { "1", "All" })]
+    [TouchPortalActionMapping("FUEL_SELECTOR_LEFT", new[] { "1", "Left" })]
+    [TouchPortalActionMapping("FUEL_SELECTOR_RIGHT", new[] { "1", "Right" })]
+    [TouchPortalActionMapping("FUEL_SELECTOR_LEFT_MAIN", new[] { "1", "Left - Main" })]
+    [TouchPortalActionMapping("FUEL_SELECTOR_RIGHT_MAIN", new[] { "1", "Right - Main" })]
+    [TouchPortalActionMapping("FUEL_SELECTOR_LEFT_AUX", new[] { "1", "Left - Aux" })]
+    [TouchPortalActionMapping("FUEL_SELECTOR_RIGHT_AUX", new[] { "1", "Right - Aux" })]
+    [TouchPortalActionMapping("FUEL_SELECTOR_CENTER", new[] { "1", "Center" })]
+
+    [TouchPortalActionMapping("FUEL_SELECTOR_2_OFF", new[] { "2", "Off" })]
+    [TouchPortalActionMapping("FUEL_SELECTOR_2_ALL", new[] { "2", "All" })]
+    [TouchPortalActionMapping("FUEL_SELECTOR_2_LEFT", new[] { "2", "Left" })]
+    [TouchPortalActionMapping("FUEL_SELECTOR_2_RIGHT", new[] { "2", "Right" })]
+    [TouchPortalActionMapping("FUEL_SELECTOR_2_LEFT_MAIN", new[] { "2", "Left - Main" })]
+    [TouchPortalActionMapping("FUEL_SELECTOR_2_RIGHT_MAIN", new[] { "2", "Right - Main" })]
+    [TouchPortalActionMapping("FUEL_SELECTOR_2_LEFT_AUX", new[] { "2", "Left - Aux" })]
+    [TouchPortalActionMapping("FUEL_SELECTOR_2_RIGHT_AUX", new[] { "2", "Right - Aux" })]
+    [TouchPortalActionMapping("FUEL_SELECTOR_2_CENTER", new[] { "2", "Center" })]
+
+    [TouchPortalActionMapping("FUEL_SELECTOR_3_OFF", new[] { "3", "Off" })]
+    [TouchPortalActionMapping("FUEL_SELECTOR_3_ALL", new[] { "3", "All" })]
+    [TouchPortalActionMapping("FUEL_SELECTOR_3_LEFT", new[] { "3", "Left" })]
+    [TouchPortalActionMapping("FUEL_SELECTOR_3_RIGHT", new[] { "3", "Right" })]
+    [TouchPortalActionMapping("FUEL_SELECTOR_3_LEFT_MAIN", new[] { "3", "Left - Main" })]
+    [TouchPortalActionMapping("FUEL_SELECTOR_3_RIGHT_MAIN", new[] { "3", "Right - Main" })]
+    [TouchPortalActionMapping("FUEL_SELECTOR_3_LEFT_AUX", new[] { "3", "Left - Aux" })]
+    [TouchPortalActionMapping("FUEL_SELECTOR_3_RIGHT_AUX", new[] { "3", "Right - Aux" })]
+    [TouchPortalActionMapping("FUEL_SELECTOR_3_CENTER", new[] { "3", "Center" })]
+
+    [TouchPortalActionMapping("FUEL_SELECTOR_4_OFF", new[] { "4", "Off" })]
+    [TouchPortalActionMapping("FUEL_SELECTOR_4_ALL", new[] { "4", "All" })]
+    [TouchPortalActionMapping("FUEL_SELECTOR_4_LEFT", new[] { "4", "Left" })]
+    [TouchPortalActionMapping("FUEL_SELECTOR_4_RIGHT", new[] { "4", "Right" })]
+    [TouchPortalActionMapping("FUEL_SELECTOR_4_RIGHT_MAIN", new[] { "4", "Right - Main" })]
+    [TouchPortalActionMapping("FUEL_SELECTOR_4_LEFT_MAIN", new[] { "4", "Left - Main" })]
+    [TouchPortalActionMapping("FUEL_SELECTOR_4_LEFT_AUX", new[] { "4", "Left - Aux" })]
+    [TouchPortalActionMapping("FUEL_SELECTOR_4_RIGHT_AUX", new[] { "4", "Right - Aux" })]
+    [TouchPortalActionMapping("FUEL_SELECTOR_4_CENTER", new[] { "4", "Center" })]
     public static object FUEL_SELECTORS { get; }
 
     [TouchPortalAction("Primers", "Toggle All/Specific Primers", "MSFS", "Toggle All/Specific Primers", "Toggle Primers - {0}")]
-    [TouchPortalActionChoice(new [] { "All", "1", "2", "3", "4" }, "All")]
+    [TouchPortalActionChoice(new [] { "All", "1", "2", "3", "4" })]
+    [TouchPortalActionMapping("TOGGLE_PRIMER", "All")]
+    [TouchPortalActionMapping("TOGGLE_PRIMER1", "1")]
+    [TouchPortalActionMapping("TOGGLE_PRIMER2", "2")]
+    [TouchPortalActionMapping("TOGGLE_PRIMER3", "3")]
+    [TouchPortalActionMapping("TOGGLE_PRIMER4", "4")]
     public static object PRIMERS { get; }
 
-
     [TouchPortalAction("FuelDump", "Fuel Dump - Toggle", "MSFS", "Toggles the Fuel Dump", "Toggle Fuel Dump")]
+    [TouchPortalActionMapping("FUEL_DUMP_TOGGLE")]
     public static object FUEL_DUMP { get; }
 
     [TouchPortalAction("CrossFeed", "Toggle/Open/Off Cross Feed", "MSFS", "Toggle/Open/Off Cross Feed", "Cross Feed - {0}")]
     [TouchPortalActionChoice(new [] { "Toggle", "Open", "Off" }, "Open")]
+    [TouchPortalActionMapping("CROSS_FEED_TOGGLE", "Toggle")]
+    [TouchPortalActionMapping("CROSS_FEED_OPEN", "Open")]
+    [TouchPortalActionMapping("CROSS_FEED_OFF", "Off")]
     public static object CROSS_FEED { get; }
 
     [TouchPortalAction("FuelValve", "Toggle All/Specific Fuel Valve", "MSFS", "Toggle All/Specific Fuel Valve", "Toggle Fuel Valve - {0}")]
-    [TouchPortalActionChoice(new [] { "All", "1", "2", "3", "4" }, "All")]
+    [TouchPortalActionChoice(new [] { "All", "1", "2", "3", "4" })]
+    [TouchPortalActionMapping("TOGGLE_FUEL_VALVE_ALL", "All")]
+    [TouchPortalActionMapping("TOGGLE_FUEL_VALVE_ENG1", "1")]
+    [TouchPortalActionMapping("TOGGLE_FUEL_VALVE_ENG2", "2")]
+    [TouchPortalActionMapping("TOGGLE_FUEL_VALVE_ENG3", "3")]
+    [TouchPortalActionMapping("TOGGLE_FUEL_VALVE_ENG4", "4")]
     public static object FUEL_VALVE { get; }
 
     #region Fuel Pump
 
     [TouchPortalAction("FuelPump", "Fuel Pump - Toggle", "MSFS", "Toggles the Fuel Pump", "Toggle Fuel Pump")]
+    [TouchPortalActionMapping("FUEL_PUMP")]
     public static object FUEL_PUMP { get; }
 
     [TouchPortalAction("ElectricFuelPump", "Electric Fuel Pump - Toggle", "MSFS", "Toggles the Electric Fuel Pump", "Toggle Electric Fuel Pump - {0}")]
-    [TouchPortalActionChoice(new [] { "All", "1", "2", "3", "4" }, "All")]
+    [TouchPortalActionChoice(new [] { "All", "1", "2", "3", "4" })]
+    [TouchPortalActionMapping("TOGGLE_ELECT_FUEL_PUMP", "All")]
+    [TouchPortalActionMapping("TOGGLE_ELECT_FUEL_PUMP1", "1")]
+    [TouchPortalActionMapping("TOGGLE_ELECT_FUEL_PUMP2", "2")]
+    [TouchPortalActionMapping("TOGGLE_ELECT_FUEL_PUMP3", "3")]
+    [TouchPortalActionMapping("TOGGLE_ELECT_FUEL_PUMP4", "4")]
     public static object ELECTRIC_FUEL_PUMP { get; }
 
     #endregion
   }
 
-  [SimNotificationGroup(Groups.Fuel)]
-  [TouchPortalCategoryMapping("InstrumentsSystems.Fuel")]
-  internal enum Fuel {
-    // Placeholder to offset each enum for SimConnect
-    Init = 2000,
 
-    // Add Fuel
-    [SimActionEvent]
-    [TouchPortalActionMapping("AddFuel")]
-    ADD_FUEL_QUANTITY,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("CrossFeed", "Off")]
-    CROSS_FEED_OFF,
-    [SimActionEvent]
-    [TouchPortalActionMapping("CrossFeed", "Open")]
-    CROSS_FEED_OPEN,
-    [SimActionEvent]
-    [TouchPortalActionMapping("CrossFeed", "Toggle")]
-    CROSS_FEED_TOGGLE,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelValve", "All")]
-    TOGGLE_FUEL_VALVE_ALL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelValve", "1")]
-    TOGGLE_FUEL_VALVE_ENG1,
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelValve", "2")]
-    TOGGLE_FUEL_VALVE_ENG2,
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelValve", "3")]
-    TOGGLE_FUEL_VALVE_ENG3,
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelValve", "4")]
-    TOGGLE_FUEL_VALVE_ENG4,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelSelectors", new [] { "1", "Off" })]
-    FUEL_SELECTOR_OFF,
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelSelectors", new [] { "1", "All" })]
-    FUEL_SELECTOR_ALL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelSelectors", new [] { "1", "Left" })]
-    FUEL_SELECTOR_LEFT,
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelSelectors", new [] { "1", "Right" })]
-    FUEL_SELECTOR_RIGHT,
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelSelectors", new [] { "1", "Left - Main"})]
-    FUEL_SELECTOR_LEFT_MAIN,
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelSelectors", new [] { "1", "Right - Main" })]
-    FUEL_SELECTOR_RIGHT_MAIN,
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelSelectors", new [] { "1", "Left - Aux" })]
-    FUEL_SELECTOR_LEFT_AUX,
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelSelectors", new [] { "1", "Right - Aux" })]
-    FUEL_SELECTOR_RIGHT_AUX,
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelSelectors", new [] { "1", "Center" })]
-    FUEL_SELECTOR_CENTER,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelSelectors", new [] { "2", "Off" })]
-    FUEL_SELECTOR_2_OFF,
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelSelectors", new [] { "2", "All" })]
-    FUEL_SELECTOR_2_ALL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelSelectors", new [] { "2", "Left" })]
-    FUEL_SELECTOR_2_LEFT,
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelSelectors", new [] { "2", "Right" })]
-    FUEL_SELECTOR_2_RIGHT,
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelSelectors", new [] { "2", "Left - Main" })]
-    FUEL_SELECTOR_2_LEFT_MAIN,
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelSelectors", new [] { "2", "Right - Main" })]
-    FUEL_SELECTOR_2_RIGHT_MAIN,
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelSelectors", new [] { "2", "Left - Aux" })]
-    FUEL_SELECTOR_2_LEFT_AUX,
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelSelectors", new [] { "2", "Right - Aux" })]
-    FUEL_SELECTOR_2_RIGHT_AUX,
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelSelectors", new [] { "2", "Center" })]
-    FUEL_SELECTOR_2_CENTER,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelSelectors", new [] { "3", "Off" })]
-    FUEL_SELECTOR_3_OFF,
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelSelectors", new [] { "3", "All" })]
-    FUEL_SELECTOR_3_ALL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelSelectors", new [] { "3", "Left" })]
-    FUEL_SELECTOR_3_LEFT,
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelSelectors", new [] { "3", "Right" })]
-    FUEL_SELECTOR_3_RIGHT,
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelSelectors", new [] { "3", "Left - Main" })]
-    FUEL_SELECTOR_3_LEFT_MAIN,
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelSelectors", new [] { "3", "Right - Main" })]
-    FUEL_SELECTOR_3_RIGHT_MAIN,
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelSelectors", new [] { "3", "Left - Aux" })]
-    FUEL_SELECTOR_3_LEFT_AUX,
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelSelectors", new [] { "3", "Right - Aux" })]
-    FUEL_SELECTOR_3_RIGHT_AUX,
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelSelectors", new [] { "3", "Center" })]
-    FUEL_SELECTOR_3_CENTER,
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelSelectors", new [] { "4", "Off" })]
-    FUEL_SELECTOR_4_OFF,
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelSelectors", new [] { "4", "All" })]
-    FUEL_SELECTOR_4_ALL,
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelSelectors", new [] { "4", "Left" })]
-    FUEL_SELECTOR_4_LEFT,
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelSelectors", new [] { "4", "Right" })]
-    FUEL_SELECTOR_4_RIGHT,
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelSelectors", new [] { "4", "Right - Main" })]
-    FUEL_SELECTOR_4_RIGHT_MAIN,
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelSelectors", new [] { "4", "Left - Main" })]
-    FUEL_SELECTOR_4_LEFT_MAIN,
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelSelectors", new [] { "4", "Left - Aux" })]
-    FUEL_SELECTOR_4_LEFT_AUX,
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelSelectors", new [] { "4", "Right - Aux" })]
-    FUEL_SELECTOR_4_RIGHT_AUX,
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelSelectors", new [] { "4", "Center" })]
-    FUEL_SELECTOR_4_CENTER,
-
-    /* 
-     * (b'FUEL_SELECTOR_SET', '''Sets selector 1 position (see code list below),
+ /*
+  FUEL_SELECTOR_SET', '''Sets selector 1 position (see code list below),
 	FUEL_TANK_SELECTOR_OFF = 0
 	FUEL_TANK_SELECTOR_ALL = 1
 	FUEL_TANK_SELECTOR_LEFT = 2
@@ -212,55 +125,12 @@ namespace MSFSTouchPortalPlugin.Objects.InstrumentsSystems {
 	FUEL_TANK_SELECTOR_CROSSFEED_R2L = 15
 	FUEL_TANK_SELECTOR_BOTH = 16
 	FUEL_TANK_SELECTOR_EXTERNAL_ALL = 17
-	FUEL_TANK_SELECTOR_ISOLATE = 18''', "Shared Cockpit"), */
+	FUEL_TANK_SELECTOR_ISOLATE = 18''', "Shared Cockpit"),
 
-    FUEL_SELECTOR_SET,
-    FUEL_SELECTOR_2_SET,
-    FUEL_SELECTOR_3_SET,
-    FUEL_SELECTOR_4_SET,
+  FUEL_SELECTOR_SET,
+  FUEL_SELECTOR_2_SET,
+  FUEL_SELECTOR_3_SET,
+  FUEL_SELECTOR_4_SET,
+ */
 
-    [SimActionEvent]
-    [TouchPortalActionMapping("Primers", "All")]
-    TOGGLE_PRIMER,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Primers", "1")]
-    TOGGLE_PRIMER1,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Primers", "2")]
-    TOGGLE_PRIMER2,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Primers", "3")]
-    TOGGLE_PRIMER3,
-    [SimActionEvent]
-    [TouchPortalActionMapping("Primers", "4")]
-    TOGGLE_PRIMER4,
-
-    // Fuel Dump
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelDump")]
-    FUEL_DUMP_TOGGLE,
-
-    #region Fuel Pump
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("FuelPump")]
-    FUEL_PUMP,
-    [SimActionEvent]
-    [TouchPortalActionMapping("ElectricFuelPump", "All")]
-    TOGGLE_ELECT_FUEL_PUMP,
-    [SimActionEvent]
-    [TouchPortalActionMapping("ElectricFuelPump", "1")]
-    TOGGLE_ELECT_FUEL_PUMP1,
-    [SimActionEvent]
-    [TouchPortalActionMapping("ElectricFuelPump", "2")]
-    TOGGLE_ELECT_FUEL_PUMP2,
-    [SimActionEvent]
-    [TouchPortalActionMapping("ElectricFuelPump", "3")]
-    TOGGLE_ELECT_FUEL_PUMP3,
-    [SimActionEvent]
-    [TouchPortalActionMapping("ElectricFuelPump", "4")]
-    TOGGLE_ELECT_FUEL_PUMP4
-
-    #endregion
-  }
 }

--- a/MSFSTouchPortalPlugin/Objects/Plugin/Plugin.cs
+++ b/MSFSTouchPortalPlugin/Objects/Plugin/Plugin.cs
@@ -13,7 +13,7 @@ namespace MSFSTouchPortalPlugin.Objects.Plugin
     [TouchPortalActionMapping("Connect", "On")]
     [TouchPortalActionMapping("Disconnect", "Off")]
     [TouchPortalState("Connected", "text", "The status of SimConnect", "false")]
-    public static object Connection { get; }
+    public static readonly object Connection;
   }
 
   [InternalEvent]

--- a/MSFSTouchPortalPlugin/Objects/Plugin/Plugin.cs
+++ b/MSFSTouchPortalPlugin/Objects/Plugin/Plugin.cs
@@ -1,4 +1,5 @@
 ﻿using MSFSTouchPortalPlugin.Attributes;
+using MSFSTouchPortalPlugin.Types;
 using TouchPortalExtension.Attributes;
 
 namespace MSFSTouchPortalPlugin.Objects.Plugin {

--- a/MSFSTouchPortalPlugin/Objects/Plugin/Plugin.cs
+++ b/MSFSTouchPortalPlugin/Objects/Plugin/Plugin.cs
@@ -2,15 +2,21 @@
 using MSFSTouchPortalPlugin.Types;
 using TouchPortalExtension.Attributes;
 
-namespace MSFSTouchPortalPlugin.Objects.Plugin {
+namespace MSFSTouchPortalPlugin.Objects.Plugin
+{
+  [InternalEvent]
   [TouchPortalCategory("Plugin", "MSFS - Plugin")]
   internal static class PluginMapping {
     [TouchPortalAction("Connection", "Connection", "MSFS", "Toggle/On/Off SimConnect Connection", "SimConnect Connection - {0}")]
-    [TouchPortalActionChoice(new [] { "Toggle", "On", "Off" }, "Toggle")]
+    [TouchPortalActionChoice(new [] { "Toggle", "On", "Off" })]
+    [TouchPortalActionMapping("ToggleConnection", "Toggle")]
+    [TouchPortalActionMapping("Connect", "On")]
+    [TouchPortalActionMapping("Disconnect", "Off")]
     [TouchPortalState("Connected", "text", "The status of SimConnect", "false")]
     public static object Connection { get; }
   }
 
+  [InternalEvent]
   [TouchPortalCategory("Plugin", "MSFS - Plugin")]
   [TouchPortalSettingsContainer]
   public static class Settings {
@@ -26,58 +32,37 @@ namespace MSFSTouchPortalPlugin.Objects.Plugin {
       Description = "Stores the held action repeat rate, which can be set via the 'MSFS - Plugin - Action Repeat Interval' action.",
       Type = "number", Default = "450", MinValue = 50, MaxValue = int.MaxValue, ReadOnly = true
     )]
-    [TouchPortalAction("ActionRepeatInterval", "Action Repeat Interval", "MSFS", "Held Action Repeat Rate (ms)", "Repeat Interval: {0} milliseconds", true)]
-    [TouchPortalActionChoice(new[] { "Increment 50ms", "Decrement 50ms", "50", "100", "200", "250", "300", "350", "400", "450", "500", "550", "600", "700", "800", "900", "1000" }, "450")]  // TODO replace with freeform value
+    [TouchPortalAction("ActionRepeatInterval", "Action Repeat Interval", "MSFS", "Held Action Repeat Rate (ms)", "Repeat Interval: {0} to/by: {1} ms", true)]
+    [TouchPortalActionChoice(new[] { "Set", "Increment", "Decrement" })]
+    [TouchPortalActionText("450", 50, int.MaxValue)]
+    [TouchPortalActionMapping("ActionRepeatIntervalSet", "Set")]
+    [TouchPortalActionMapping("ActionRepeatIntervalInc", "Increment")]
+    [TouchPortalActionMapping("ActionRepeatIntervalDec", "Decrement")]
     [TouchPortalState("ActionRepeatInterval", "text", "The current Held Action Repeat Rate (ms)", "450")]
     public static readonly PluginSetting ActionRepeatInterval = new PluginSetting("ActionRepeatInterval", 50, int.MaxValue);
   }
 
-  [InternalEvent]
-  [TouchPortalCategoryMapping("Plugin")]
+  // IDs for handling internal events
   internal enum Plugin : short {
     // Starting point
     Init = 255,
 
-    [TouchPortalActionMapping("Connection", "Toggle")]
     ToggleConnection,
-    [TouchPortalActionMapping("Connection", "On")]
     Connect,
-    [TouchPortalActionMapping("Connection", "Off")]
     Disconnect,
 
-    [TouchPortalActionMapping("ActionRepeatInterval", "Increment 50ms")]
     ActionRepeatIntervalInc,
-    [TouchPortalActionMapping("ActionRepeatInterval", "Decrement 50ms")]
     ActionRepeatIntervalDec,
-    [TouchPortalActionMapping("ActionRepeatInterval", "50")]
-    ActionRepeatInterval50,
-    [TouchPortalActionMapping("ActionRepeatInterval", "100")]
-    ActionRepeatInterval100,
-    [TouchPortalActionMapping("ActionRepeatInterval", "200")]
-    ActionRepeatInterval200,
-    [TouchPortalActionMapping("ActionRepeatInterval", "250")]
-    ActionRepeatInterval250,
-    [TouchPortalActionMapping("ActionRepeatInterval", "300")]
-    ActionRepeatInterval300,
-    [TouchPortalActionMapping("ActionRepeatInterval", "350")]
-    ActionRepeatInterval350,
-    [TouchPortalActionMapping("ActionRepeatInterval", "400")]
-    ActionRepeatInterval400,
-    [TouchPortalActionMapping("ActionRepeatInterval", "450")]
-    ActionRepeatInterval450,
-    [TouchPortalActionMapping("ActionRepeatInterval", "500")]
-    ActionRepeatInterval500,
-    [TouchPortalActionMapping("ActionRepeatInterval", "550")]
-    ActionRepeatInterval550,
-    [TouchPortalActionMapping("ActionRepeatInterval", "600")]
-    ActionRepeatInterval600,
-    [TouchPortalActionMapping("ActionRepeatInterval", "700")]
-    ActionRepeatInterval700,
-    [TouchPortalActionMapping("ActionRepeatInterval", "800")]
-    ActionRepeatInterval800,
-    [TouchPortalActionMapping("ActionRepeatInterval", "900")]
-    ActionRepeatInterval900,
-    [TouchPortalActionMapping("ActionRepeatInterval", "1000")]
-    ActionRepeatInterval1000,
+    ActionRepeatIntervalSet,
+  }
+
+  // Dynamicaly generated SimConnect client event IDs are "parented" to this enum type,
+  // meaning they become of this Type when they need to be cast to en Enum type (eg. for SimConnect C# API).
+  // This is done by the ReflectionService when generating the list of events for SimConnect.
+  // They really could be cast any any Enum type at all, so this is mostly for semantics.
+  internal enum SimEventClientId
+  {
+    // Starting point
+    Init = 1000,
   }
 }

--- a/MSFSTouchPortalPlugin/Objects/Plugin/PluginSetting.cs
+++ b/MSFSTouchPortalPlugin/Objects/Plugin/PluginSetting.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-using TouchPortalExtension.Attributes;
+using TouchPortalExtension.Enums;
 
 namespace MSFSTouchPortalPlugin.Objects.Plugin
 {
@@ -23,31 +23,7 @@ namespace MSFSTouchPortalPlugin.Objects.Plugin
         return _value;
       }
       set {
-        if (ValueType == DataType.Number) {
-          if (!value.GetType().IsAssignableTo(typeof(double))) {
-            _value = null;
-          }
-          else {
-            double realVal = (double)value;
-            if (!double.IsNaN(MinValue))
-              realVal = Math.Max(realVal, MinValue);
-            if (!double.IsNaN(MaxValue))
-              realVal = Math.Min(realVal, MaxValue);
-            _value = realVal;
-          }
-        }
-        // string
-        else {
-          if (!value.GetType().IsAssignableTo(typeof(string))) {
-            _value = null;
-          }
-          else {
-            string strVal = (string)value;
-            if (MaxLength > 0 && strVal.Length > MaxLength)
-              strVal = strVal.Remove(MaxLength + 1);
-            _value = strVal;
-          }
-        }
+        SetValueDynamic(value);
       }
     }
 
@@ -57,6 +33,29 @@ namespace MSFSTouchPortalPlugin.Objects.Plugin
           Value = numVal;
       } else {
         Value = value;
+      }
+    }
+
+    public void SetValueDynamic(dynamic value) {
+      try {
+        if (ValueType == DataType.Number) {
+          double realVal = Convert.ToDouble(value); ;
+          if (!double.IsNaN(MinValue))
+            realVal = Math.Max(realVal, MinValue);
+          if (!double.IsNaN(MaxValue))
+            realVal = Math.Min(realVal, MaxValue);
+          _value = realVal;
+        }
+        // string
+        else {
+          string strVal = Convert.ToString(value);
+          if (MaxLength > 0 && !string.IsNullOrEmpty(strVal))
+            strVal = strVal[..Math.Min(strVal.Length, MaxLength)];
+          _value = strVal;
+        }
+      }
+      catch (Exception e) {
+        throw new ArgumentException("Cannot convert value to intended type.", e);
       }
     }
 

--- a/MSFSTouchPortalPlugin/Objects/SimSystem/SimSystem.cs
+++ b/MSFSTouchPortalPlugin/Objects/SimSystem/SimSystem.cs
@@ -3,20 +3,26 @@ using MSFSTouchPortalPlugin.Constants;
 using MSFSTouchPortalPlugin.Enums;
 using TouchPortalExtension.Attributes;
 
-namespace MSFSTouchPortalPlugin.Objects.SimSystem {
+namespace MSFSTouchPortalPlugin.Objects.SimSystem 
+{
   [SimVarDataRequestGroup]
+  [SimNotificationGroup(Groups.SimSystem)]
   [TouchPortalCategory("SimSystem", "MSFS - System")]
   internal static class SimSystemMapping {
     [SimVarDataRequest]
     [TouchPortalAction("SimulationRate", "Simulation Rate", "MSFS", "Simulation Rate", "Rate {0}", true)]
-    [TouchPortalActionChoice(new [] { "Increase", "Decrease" }, "Decrease")]
+    [TouchPortalActionChoice(new [] { "Increase", "Decrease" })]
+    [TouchPortalActionMapping("SIM_RATE_INCR", "Increase")]
+    [TouchPortalActionMapping("SIM_RATE_DECR", "Decrease")]
     [TouchPortalState("SimulationRate", "text", "The current simulation rate", "")]
     public static readonly SimVarItem SimulationRate =
       new SimVarItem { Def = Definition.SimulationRate, SimVarName = "SIMULATION RATE", Unit = Units.number, CanSet = false };
 
     [SimVarDataRequest]
     [TouchPortalAction("SelectedParameter", "Change Selected Value (+/-)", "MSFS", "Selected Value", "Value {0}", true)]
-    [TouchPortalActionChoice(new[] { "Increase", "Decrease" }, "Decrease")]
+    [TouchPortalActionChoice(new[] { "Increase", "Decrease" })]
+    [TouchPortalActionMapping("PLUS", "Increase")]
+    [TouchPortalActionMapping("MINUS", "Decrease")]
     public static object SELECTED_PARAMETER_CHANGE { get; }
 
     [SimVarDataRequest]
@@ -42,34 +48,5 @@ namespace MSFSTouchPortalPlugin.Objects.SimSystem {
     [SimVarDataRequest]
     [TouchPortalState("AircraftTitle", "text", "Aircraft Title", "")]
     public static readonly SimVarItem AircraftTitle = new SimVarItem { Def = Definition.AircraftTitle, SimVarName = "TITLE", Unit = Units.String, CanSet = false };
-  }
-
-  [SimNotificationGroup(Groups.SimSystem)]
-  [TouchPortalCategoryMapping("SimSystem")]
-  internal enum SimSystem {
-    // Placeholder to offset each enum for SimConnect
-    Init = 3000,
-
-    #region KeySelect
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("SelectedParameter", "Increase")]
-    PLUS,
-    [SimActionEvent]
-    [TouchPortalActionMapping("SelectedParameter", "Decrease")]
-    MINUS,
-
-    #endregion
-
-    #region SimRate
-
-    [SimActionEvent]
-    [TouchPortalActionMapping("SimulationRate", "Increase")]
-    SIM_RATE_INCR,
-    [SimActionEvent]
-    [TouchPortalActionMapping("SimulationRate", "Decrease")]
-    SIM_RATE_DECR,
-
-    #endregion
   }
 }

--- a/MSFSTouchPortalPlugin/Objects/SimSystem/SimSystem.cs
+++ b/MSFSTouchPortalPlugin/Objects/SimSystem/SimSystem.cs
@@ -3,7 +3,7 @@ using MSFSTouchPortalPlugin.Constants;
 using MSFSTouchPortalPlugin.Enums;
 using TouchPortalExtension.Attributes;
 
-namespace MSFSTouchPortalPlugin.Objects.SimSystem 
+namespace MSFSTouchPortalPlugin.Objects.SimSystem
 {
   [SimVarDataRequestGroup]
   [SimNotificationGroup(Groups.SimSystem)]
@@ -11,7 +11,7 @@ namespace MSFSTouchPortalPlugin.Objects.SimSystem
   internal static class SimSystemMapping {
     [SimVarDataRequest]
     [TouchPortalAction("SimulationRate", "Simulation Rate", "MSFS", "Simulation Rate", "Rate {0}", true)]
-    [TouchPortalActionChoice(new [] { "Increase", "Decrease" })]
+    [TouchPortalActionChoice(new [] { "Increase", "Decrease" }, "Decrease")]
     [TouchPortalActionMapping("SIM_RATE_INCR", "Increase")]
     [TouchPortalActionMapping("SIM_RATE_DECR", "Decrease")]
     [TouchPortalState("SimulationRate", "text", "The current simulation rate", "")]
@@ -20,7 +20,7 @@ namespace MSFSTouchPortalPlugin.Objects.SimSystem
 
     [SimVarDataRequest]
     [TouchPortalAction("SelectedParameter", "Change Selected Value (+/-)", "MSFS", "Selected Value", "Value {0}", true)]
-    [TouchPortalActionChoice(new[] { "Increase", "Decrease" })]
+    [TouchPortalActionChoice(new[] { "Increase", "Decrease" }, "Decrease")]
     [TouchPortalActionMapping("PLUS", "Increase")]
     [TouchPortalActionMapping("MINUS", "Decrease")]
     public static object SELECTED_PARAMETER_CHANGE { get; }

--- a/MSFSTouchPortalPlugin/Services/PluginService.cs
+++ b/MSFSTouchPortalPlugin/Services/PluginService.cs
@@ -272,24 +272,17 @@ namespace MSFSTouchPortalPlugin.Services {
 
       switch (pluginEventId) {
         case Plugin.ToggleConnection:
-          if (_simConnectService.IsConnected()) {
-            autoReconnectSimConnect = false;
+          autoReconnectSimConnect = !autoReconnectSimConnect;
+          if (_simConnectService.IsConnected())
             _simConnectService.Disconnect();
-          }
-          else {
-            autoReconnectSimConnect = true;
-          }
           break;
         case Plugin.Connect:
-          if (!_simConnectService.IsConnected()) {
-            autoReconnectSimConnect = true;
-          }
+          autoReconnectSimConnect = true;
           break;
         case Plugin.Disconnect:
-          if (_simConnectService.IsConnected()) {
-            autoReconnectSimConnect = false;
+          autoReconnectSimConnect = false;
+          if (_simConnectService.IsConnected())
             _simConnectService.Disconnect();
-          }
           break;
 
         case Plugin.ActionRepeatIntervalInc:

--- a/MSFSTouchPortalPlugin/Services/PluginService.cs
+++ b/MSFSTouchPortalPlugin/Services/PluginService.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
-using MSFSTouchPortalPlugin.Attributes;
 using MSFSTouchPortalPlugin.Constants;
 using MSFSTouchPortalPlugin.Interfaces;
 using MSFSTouchPortalPlugin.Objects.Plugin;
@@ -9,10 +8,10 @@ using System;
 using System.Collections.Generic;
 using System.Collections.Concurrent;
 using System.Linq;
-using System.Reflection;
 using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
+using TouchPortalExtension.Enums;
 using TouchPortalSDK;
 using TouchPortalSDK.Interfaces;
 using TouchPortalSDK.Messages.Events;
@@ -29,13 +28,13 @@ namespace MSFSTouchPortalPlugin.Services {
     private readonly ITouchPortalClient _client;
     private readonly ISimConnectService _simConnectService;
     private readonly IReflectionService _reflectionService;
+    private static readonly System.Data.DataTable _expressionEvaluator = new();  // used to evaluate basic math in action data
     private bool autoReconnectSimConnect = false;
 
     public string PluginId => "MSFSTouchPortalPlugin";
 
-    private Dictionary<string, Enum> actionsDictionary = new Dictionary<string, Enum>();
-    private Dictionary<Definition, SimVarItem> statesDictionary = new Dictionary<Definition, SimVarItem>();
-    private Dictionary<string, Enum> internalEventsDictionary = new Dictionary<string, Enum>();
+    private Dictionary<string, ActionEventType> actionsDictionary = new();
+    private Dictionary<Definition, SimVarItem> statesDictionary = new();
     private Dictionary<string, PluginSetting> pluginSettingsDictionary = new();
 
     private readonly ConcurrentDictionary<string, Timer> repeatingActionTimers = new();
@@ -171,9 +170,10 @@ namespace MSFSTouchPortalPlugin.Services {
       _client.StateUpdate("MSFSTouchPortalPlugin.Plugin.State.Connected", _simConnectService.IsConnected().ToString().ToLower());
 
       // Register Actions
-      foreach (var a in actionsDictionary) {
-        _simConnectService.MapClientEventToSimEvent(a.Value, a.Value.ToString());
-        _simConnectService.AddNotification(a.Value.GetType().GetCustomAttribute<SimNotificationGroupAttribute>().Group, a.Value);
+      var eventMap = _reflectionService.GetClientEventIdToNameMap();
+      foreach (var m in eventMap) {
+        _simConnectService.MapClientEventToSimEvent(m.Key, m.Value.EventName);
+        _simConnectService.AddNotification(m.Value.GroupId, m.Key);
       }
       // must be called after adding notifications
       _simConnectService.SetNotificationGroupPriorities();
@@ -227,7 +227,6 @@ namespace MSFSTouchPortalPlugin.Services {
     #endregion
 
     private void SetupEventLists() {
-      internalEventsDictionary = _reflectionService.GetInternalEvents();
       actionsDictionary = _reflectionService.GetActionEvents();
       statesDictionary = _reflectionService.GetStates();
       pluginSettingsDictionary = _reflectionService.GetSettings();
@@ -253,75 +252,107 @@ namespace MSFSTouchPortalPlugin.Services {
       return Task.CompletedTask;
     }
 
-    private void ProcessEvent(string actionId, string value = default) {
-      // Plugin Events
-      if (internalEventsDictionary.TryGetValue($"{actionId}:{value}", out var internalEventResult)) {
-        _logger.LogInformation($"{DateTime.Now} {internalEventResult} - Firing Internal Event");
-        Plugin typedResult = (Plugin)internalEventResult;
-
-        switch (typedResult) {
-          case Plugin.ToggleConnection:
-            if (_simConnectService.IsConnected()) {
-              autoReconnectSimConnect = false;
-              _simConnectService.Disconnect();
-            } else {
-              autoReconnectSimConnect = true;
-            }
-            break;
-          case Plugin.Connect:
-            if (!_simConnectService.IsConnected()) {
-              autoReconnectSimConnect = true;
-            }
-            break;
-          case Plugin.Disconnect:
-            if (_simConnectService.IsConnected()) {
-              autoReconnectSimConnect = false;
-              _simConnectService.Disconnect();
-            }
-            break;
-
-          case Plugin.ActionRepeatIntervalInc:
-          case Plugin.ActionRepeatIntervalDec: {
-              var interval = Settings.ActionRepeatInterval.ValueAsDbl();
-              if (typedResult == Plugin.ActionRepeatIntervalInc)
-                interval = Math.Min(interval + 50, Settings.ActionRepeatInterval.MaxValue);
-              else
-                interval = Math.Max(interval - 50, Settings.ActionRepeatInterval.MinValue);
-              if (interval != Settings.ActionRepeatInterval.ValueAsDbl())
-                _client.SettingUpdate(Settings.ActionRepeatInterval.Name, $"{interval:F0}");  // this will trigger the actual value update
-            }
-            break;
-
-          // FIXME when we can use freeform values in action data
-          case var n when (n >= Plugin.ActionRepeatInterval50 && n <= Plugin.ActionRepeatInterval1000):
-            _client.SettingUpdate(Settings.ActionRepeatInterval.Name, value);  // this will trigger the actual value update
-            break;
-
-          default:
-            // No other types of events supported right now.
-            break;
-        }
-
+    private void ProcessEvent(ActionEvent actionEvent) {
+      if (!actionsDictionary.TryGetValue(actionEvent.ActionId, out ActionEventType action))
         return;
-      }
 
-      // Sim Events
-      if (actionsDictionary.TryGetValue($"{actionId}:{value}", out var eventResult)) {
-        _logger.LogInformation($"{DateTime.Now} {eventResult} - Firing Event");
-        var group = eventResult.GetType().GetCustomAttribute<SimNotificationGroupAttribute>().Group;
-        _simConnectService.TransmitClientEvent(group, eventResult, 0);
+      var dataArry = actionEvent.Data.Select(x => x.Value).ToArray();
+      if (!action.TryGetEventMapping(in dataArry, out Enum eventId))
+        return;
+
+      if (action.InternalEvent)
+        ProcessInternalEvent(action, eventId, in dataArry);
+      else
+        ProcessSimEvent(action, eventId, in dataArry);
+    }
+
+    private void ProcessInternalEvent(ActionEventType action, Enum eventId, in string[] dataArry) {
+      Plugin pluginEventId = (Plugin)eventId;
+      _logger.LogInformation($"Firing Internal Event - action: {action.ActionId}; enum: {pluginEventId}; data: {string.Join(", ", dataArry)}");
+
+      switch (pluginEventId) {
+        case Plugin.ToggleConnection:
+          if (_simConnectService.IsConnected()) {
+            autoReconnectSimConnect = false;
+            _simConnectService.Disconnect();
+          }
+          else {
+            autoReconnectSimConnect = true;
+          }
+          break;
+        case Plugin.Connect:
+          if (!_simConnectService.IsConnected()) {
+            autoReconnectSimConnect = true;
+          }
+          break;
+        case Plugin.Disconnect:
+          if (_simConnectService.IsConnected()) {
+            autoReconnectSimConnect = false;
+            _simConnectService.Disconnect();
+          }
+          break;
+
+        case Plugin.ActionRepeatIntervalInc:
+        case Plugin.ActionRepeatIntervalDec:
+        case Plugin.ActionRepeatIntervalSet:
+          if (action.ValueIndex < dataArry.Length && double.TryParse(dataArry[action.ValueIndex], out var interval)) {
+            if (pluginEventId == Plugin.ActionRepeatIntervalInc)
+              interval = Settings.ActionRepeatInterval.ValueAsDbl() + interval;
+            else if (pluginEventId == Plugin.ActionRepeatIntervalDec)
+              interval = Settings.ActionRepeatInterval.ValueAsDbl() - interval;
+            interval = Math.Clamp(interval, Settings.ActionRepeatInterval.MinValue, Settings.ActionRepeatInterval.MaxValue);
+            if (interval != Settings.ActionRepeatInterval.ValueAsDbl())
+              _client.SettingUpdate(Settings.ActionRepeatInterval.Name, $"{interval:F0}");  // this will trigger the actual value update
+          }
+          break;
+
+        default:
+          // No other types of events supported right now.
+          break;
       }
     }
 
+    private void ProcessSimEvent(ActionEventType action, Enum eventId, in string[] dataArry) {
+      uint dataUint = 0;
+      string eventName = _reflectionService.GetSimEventNameById(eventId);  // just for logging
+      if (action.ValueIndex > -1 && action.ValueIndex < dataArry.Length) {
+        double dataReal = double.NaN;
+        var valStr = dataArry[action.ValueIndex];
+        try {
+          switch (action.ValueType) {
+            case DataType.Number:
+            case DataType.Text:
+              dataReal = Convert.ToDouble(_expressionEvaluator.Compute(valStr, null));
+              break;
+            case DataType.Switch:
+              dataReal = new BooleanString(valStr);
+              break;
+          }
+          if (!double.IsNaN(dataReal)) {
+            if (!double.IsNaN(action.MinValue))
+              dataReal = Math.Max(dataReal, action.MinValue);
+            if (!double.IsNaN(action.MaxValue))
+              dataReal = Math.Min(dataReal, action.MaxValue);
+            dataUint = Convert.ToUInt32(dataReal);
+          }
+        }
+        catch (Exception e) {
+          _logger.LogWarning(e, $"Action {action.ActionId} for sim event {eventName} with data string '{valStr}' - Failed to convert data to numeric value.");
+        }
+      }
+      _logger.LogInformation($"Firing Sim Event - action: {action.ActionId}; group: {action.SimConnectGroup}; name: {eventName}; data {dataUint}");
+      _simConnectService.TransmitClientEvent(action.SimConnectGroup, eventId, dataUint);
+    }
+
     private void CheckPendingRequests() {
-      foreach (var s in statesDictionary) {
+      foreach (var s in statesDictionary.Values) {
         // Expire pending if more than 30 seconds
-        s.Value.PendingTimeout();
+        s.PendingTimeout();
 
         // Check if Pending data request in paly
-        if (!s.Value.PendingRequest) {
-          _simConnectService.RequestDataOnSimObjectType(s.Value);
-          s.Value.SetPending(true);
+        if (!s.PendingRequest) {
+          s.SetPending(true);
+          _simConnectService.RequestDataOnSimObjectType(s);
         }
       }
     }
@@ -373,13 +404,7 @@ namespace MSFSTouchPortalPlugin.Services {
       ProcessPluginSettings(message.Values);
     }
 
-    public void OnActionEvent(ActionEvent message)
-    {
-      //_logger.LogInformation($"ACTION {message.Type}");
-      string values = default;
-      if (message.Data.Count > 0)
-        values = string.Join(",", message.Data.Select(x => x.Value));
-
+    public void OnActionEvent(ActionEvent message) {
       // Actions used in TP "On Hold" events will send "down" and "up" events, in that order (usually).
       // "On Pressed" actions will have an "action" event. These are all abstracted into TouchPortalSDK enums.
       // Note that an "On Hold" action ("down" event) is _not_ triggered upon initial press. This allow different
@@ -388,7 +413,7 @@ namespace MSFSTouchPortalPlugin.Services {
         case TouchPortalSDK.Messages.Models.Enums.Press.Down:
           // "On Hold" activated ("down" event). Try to add this action to the repeating/scheduled actions queue, unless it already exists.
           var timer = new Timer(Settings.ActionRepeatInterval.ValueAsInt());
-          timer.Elapsed += delegate { ProcessEvent(message.ActionId, values); };
+          timer.Elapsed += delegate { ProcessEvent(message); };
           if (repeatingActionTimers.TryAdd(message.ActionId, timer))
             timer.Start();
           else
@@ -404,7 +429,7 @@ namespace MSFSTouchPortalPlugin.Services {
 
         case TouchPortalSDK.Messages.Models.Enums.Press.Tap:
           // Process an "On Pressed" ("action" event) action.
-          ProcessEvent(message.ActionId, values);
+          ProcessEvent(message);
           break;
       }
     }

--- a/MSFSTouchPortalPlugin/Services/PluginService.cs
+++ b/MSFSTouchPortalPlugin/Services/PluginService.cs
@@ -4,6 +4,7 @@ using MSFSTouchPortalPlugin.Attributes;
 using MSFSTouchPortalPlugin.Constants;
 using MSFSTouchPortalPlugin.Interfaces;
 using MSFSTouchPortalPlugin.Objects.Plugin;
+using MSFSTouchPortalPlugin.Types;
 using System;
 using System.Collections.Generic;
 using System.Collections.Concurrent;

--- a/MSFSTouchPortalPlugin/Services/PluginService.cs
+++ b/MSFSTouchPortalPlugin/Services/PluginService.cs
@@ -326,7 +326,7 @@ namespace MSFSTouchPortalPlugin.Services {
               dataReal = Math.Max(dataReal, action.MinValue);
             if (!double.IsNaN(action.MaxValue))
               dataReal = Math.Min(dataReal, action.MaxValue);
-            dataUint = Convert.ToUInt32(dataReal);
+            dataUint = (uint)Math.Round(dataReal);
           }
         }
         catch (Exception e) {

--- a/MSFSTouchPortalPlugin/Services/ReflectionService.cs
+++ b/MSFSTouchPortalPlugin/Services/ReflectionService.cs
@@ -1,7 +1,7 @@
 ﻿using MSFSTouchPortalPlugin.Attributes;
 using MSFSTouchPortalPlugin.Constants;
 using MSFSTouchPortalPlugin.Interfaces;
-using MSFSTouchPortalPlugin.Objects.Plugin;
+using MSFSTouchPortalPlugin.Types;
 using System;
 using System.Collections.Generic;
 using System.Linq;

--- a/MSFSTouchPortalPlugin/Services/ReflectionService.cs
+++ b/MSFSTouchPortalPlugin/Services/ReflectionService.cs
@@ -1,62 +1,94 @@
-﻿using MSFSTouchPortalPlugin.Attributes;
+﻿using Microsoft.Extensions.Logging;
+using MSFSTouchPortalPlugin.Attributes;
 using MSFSTouchPortalPlugin.Constants;
+using MSFSTouchPortalPlugin.Enums;
 using MSFSTouchPortalPlugin.Interfaces;
+using MSFSTouchPortalPlugin.Objects.Plugin;
 using MSFSTouchPortalPlugin.Types;
 using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using TouchPortalExtension.Attributes;
+using TouchPortalExtension.Enums;
 
 namespace MSFSTouchPortalPlugin.Services {
   internal class ReflectionService : IReflectionService {
     private readonly string rootName = Assembly.GetExecutingAssembly().GetName().Name;
+    private readonly ILogger<ReflectionService> _logger;
 
-    public Dictionary<string, Enum> GetInternalEvents() {
-      var returnDict = new Dictionary<string, Enum>();
-
-      // Map internal events
-      var internalEventList = Assembly.GetExecutingAssembly().GetTypes().Where(t => t.IsEnum && t.GetCustomAttribute<InternalEventAttribute>() != null).ToList();
-      internalEventList.ForEach(internalEvent => {
-        string catName = internalEvent.GetCustomAttribute<TouchPortalCategoryMappingAttribute>().CategoryId;
-
-        var list = internalEvent.GetFields().Where(f => f.GetCustomAttribute<TouchPortalActionMappingAttribute>() != null).ToList();
-
-        list.ForEach(ie => {
-          var actionName = ie.GetCustomAttribute<TouchPortalActionMappingAttribute>().ActionId;
-          var actionValues = ie.GetCustomAttribute<TouchPortalActionMappingAttribute>().Values;
-
-          if (Enum.TryParse(ie.ReflectedType, ie.Name, out dynamic result)) {
-            // Put into collection
-            returnDict.TryAdd($"{rootName}.{catName}.Action.{actionName}:{string.Join(",", actionValues)}", result);
-          }
-        });
-      });
-
-      return returnDict;
+    public ReflectionService(ILogger<ReflectionService> logger) {
+      _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
-    public Dictionary<string, Enum> GetActionEvents() {
-      var returnDict = new Dictionary<string, Enum>();
+    // Mapping of the generated SimConnect client event ID Enum to the SimConnect event name and group id.
+    // Primarily used to register events with SimConnect, but can also be useful for debug/logging.
+    // Structure is: <Event ID> -> new { string EventName, Enums.Groups GroupId }
+    private static readonly Dictionary<Enum, dynamic> clientEventIdToNameMap = new();
 
-      // Map all Sim Events to the Sim
-      var enumList = Assembly.GetExecutingAssembly().GetTypes().Where(t => t.IsEnum && t.GetCustomAttribute<SimNotificationGroupAttribute>() != null).ToList();
-      enumList.ForEach(enumValue => {
-        // Get the notification group to register
-        var catName = enumValue.GetCustomAttribute<TouchPortalCategoryMappingAttribute>().CategoryId;
-        // Configure SimConnect action mappings
-        var events = enumValue.GetMembers().Where(m => m.CustomAttributes.Any(att => att.AttributeType == typeof(SimActionEventAttribute))).ToList();
+    public ref readonly Dictionary<Enum, dynamic> GetClientEventIdToNameMap() => ref clientEventIdToNameMap;
+    public string GetSimEventNameById(Enum id) {
+      return clientEventIdToNameMap.TryGetValue(id, out var entry) ? entry.EventName : "[unknown event]";
+    }
+    public string GetSimEventNameById(uint id) => GetSimEventNameById((SimEventClientId)id);
+    public string GetSimEventNameById(int id) => GetSimEventNameById((SimEventClientId)id);
 
-        events.ForEach(e => {
-          // Map the touch portal action to the Sim Event
-          if (Enum.TryParse(e.ReflectedType, e.Name, out dynamic result)) {
-            // Register to Touch Portal
-            string actionName = e.GetCustomAttribute<TouchPortalActionMappingAttribute>().ActionId;
-            var actionValues = e.GetCustomAttribute<TouchPortalActionMappingAttribute>().Values;
+    public Dictionary<string, ActionEventType> GetActionEvents() {
+      var returnDict = new Dictionary<string, ActionEventType>();
+      int nextId = (int)SimEventClientId.Init + 1;
 
-            // Put into collection
-            returnDict.TryAdd($"{rootName}.{catName}.Action.{actionName}:{string.Join(",", actionValues)}", result);
+      // Get all types which have actions mapped to events, sim or internal.
+      var eventContainers = Assembly.GetExecutingAssembly().GetTypes().Where(
+        t => t.IsClass && (t.GetCustomAttribute<SimNotificationGroupAttribute>() != null || t.GetCustomAttribute<InternalEventAttribute>() != null)
+      ).ToList();
+      eventContainers.ForEach(notifyType => {
+        // Get the TP Category ID for this type
+        var catName = notifyType.GetCustomAttribute<TouchPortalCategoryAttribute>().Id;
+        // And the SimConnect Group ID
+        Groups simGroup = notifyType.GetCustomAttribute<SimNotificationGroupAttribute>()?.Group ?? default;
+        var internalEvent = simGroup == default;
+        // Get all members which have an action mapping, which is some unique combination of value(s) mapped to a SimConnect event name or internal event enum
+        List<MemberInfo> actionMembers = notifyType.GetMembers().Where(m => m.CustomAttributes.Any(att => att.AttributeType == typeof(TouchPortalActionMappingAttribute))).ToList();
+        actionMembers.ForEach(e => {
+          // Create the action data object to store in the return dict, using the meta data we've collected so far.
+          ActionEventType act = new ActionEventType {
+            InternalEvent = internalEvent,
+            SimConnectGroup = simGroup,
+            ActionId = e.GetCustomAttribute<TouchPortalActionAttribute>().Id,
+            //ActionObject = e
+          };
+          // Loop over all the data attributes to find the "choice" types for mapping and also the index of any freeform data value field
+          var dataAttribs = e.GetCustomAttributes<TouchPortalActionDataAttribute>().ToList() ?? new();
+          for (var i = 0; i < dataAttribs.Count; ++i) {
+            var dataAttrib = dataAttribs[i];
+            if (dataAttrib.ValueType == DataType.Choice) {
+              // for Choice types, we combine them to create a unique lookup key which maps to a particular event.
+              if (act.KeyFormatStr.Length > 1)
+                act.KeyFormatStr += ",";
+              act.KeyFormatStr += $"{{{i}}}";
+            }
+            else {
+              // we only support one freeform value per mapping, which is all SimConnect supports, and internal events can handle the data as necessary already.
+              act.ValueIndex = i;
+              act.MinValue = dataAttrib.MinValue;
+              act.MaxValue = dataAttrib.MaxValue;
+              act.ValueType = dataAttrib.ValueType;
+            }
           }
+          // Now get all the action mappings to produce the final list of all possible action events
+          var mappingAttribs = e.GetCustomAttributes<TouchPortalActionMappingAttribute>()?.ToList();
+          mappingAttribs?.ForEach(ma => {
+            Enum mapTarget = internalEvent ? Enum.Parse<Plugin>(ma.ActionId) : (SimEventClientId)nextId++;
+            // Put into collections
+            if (!act.TpActionToEventMap.TryAdd($"{string.Join(",", ma.Values)}", mapTarget))
+              _logger.LogWarning($"Duplicate action-to-event mapping found for action {act.ActionId} with choices '{string.Join(",", ma.Values)} for event '{ma.ActionId}'!'");
+            // keep track of generated event IDs for Sim actions (for registering to SimConnect, and debug)
+            if (!internalEvent)
+              clientEventIdToNameMap[mapTarget] = new { EventName = ma.ActionId, GroupId = simGroup };
+          });
+          // Put into returned collection
+          if (!returnDict.TryAdd($"{rootName}.{catName}.Action.{act.ActionId}", act))
+            _logger.LogWarning($"Duplicate action ID found for action '{act.ActionId}' in category '{catName}', skipping.'");
         });
       });
 
@@ -97,7 +129,7 @@ namespace MSFSTouchPortalPlugin.Services {
               settingsObj.Name = settingAttr.Name;
             if (settingsObj.Default == null)
               settingsObj.Default = settingAttr.Default;
-            if (settingsObj.TouchPortalStateId == null && (settingField.GetCustomAttribute<TouchPortalStateAttribute>()?.Id is var stateId && stateId != null))
+            if (settingsObj.TouchPortalStateId == null && settingField.GetCustomAttribute<TouchPortalStateAttribute>()?.Id is var stateId && stateId != null)
               settingsObj.TouchPortalStateId = $"{rootName}.Plugin.State.{stateId}";
             returnDict.TryAdd(settingAttr.Name, settingsObj);
           }

--- a/MSFSTouchPortalPlugin/Services/SimConnectService.cs
+++ b/MSFSTouchPortalPlugin/Services/SimConnectService.cs
@@ -296,13 +296,15 @@ namespace MSFSTouchPortalPlugin.Services {
     #endregion
   }
 
-  struct StringVal64 : IEquatable<StringVal64> {
+  internal readonly struct StringVal64 : IEquatable<StringVal64> {
     [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 64)]
-    public string Value;
+    public readonly string Value;
 
     public bool Equals(StringVal64 other) => other.Value == Value;
     public override bool Equals(object obj) => (obj is StringVal64 && Equals((StringVal64)obj));
     public override string ToString() => Value;
     public override int GetHashCode() => Value.GetHashCode();
+    public static bool operator ==(StringVal64 obj1, StringVal64 obj2) => obj1.Equals(obj2);
+    public static bool operator !=(StringVal64 obj1, StringVal64 obj2) => !obj1.Equals(obj2);
   }
 }

--- a/MSFSTouchPortalPlugin/Types/ActionEventType.cs
+++ b/MSFSTouchPortalPlugin/Types/ActionEventType.cs
@@ -1,0 +1,50 @@
+﻿using MSFSTouchPortalPlugin.Enums;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using TouchPortalExtension.Enums;
+
+namespace MSFSTouchPortalPlugin.Types
+{
+  internal class ActionEventType
+  {
+    public bool InternalEvent = false;
+    public Groups SimConnectGroup;
+    public string ActionId;
+    public int ValueIndex = -1;
+    public string KeyFormatStr = string.Empty;
+    public double MinValue = double.NaN;  // for basic validation of a single value
+    public double MaxValue = double.NaN;
+    public DataType ValueType = DataType.None;  // assuming single value here also
+
+    // Mapping of TP actions to SimConnect or "Native" events. For SimConnect, the Enum is a generated number
+    // of type SimEventClientId (but doesn't actually exist), and for internal plugin events its an actual
+    // member of the MSFSTouchPortalPlugin.Objects.Plugin.Plugin enum.
+    public readonly Dictionary<string, Enum> TpActionToEventMap = new();
+
+    // possible future use
+    //public object ActionObject = null;  // the member to which all action attributes are assigned to
+    //public IReadOnlyCollection<TouchPortalActionDataAttribute> DataAttributes;  // list of all data type attributes
+
+    // Get a unique event ID for this action, possibly based on data values
+    // in the \c data array. Certain combination of values, eg. from choices,
+    // may have their own unique events. Returns `false` if the lookup fails.
+    public bool TryGetEventMapping(in string[] values, out Enum eventEnum) {
+      if (TpActionToEventMap.Count == 1) {
+        eventEnum = TpActionToEventMap.First().Value;
+        return true;
+      }
+      return TpActionToEventMap.TryGetValue(FormatLookupKey(values), out eventEnum);
+    }
+
+    // Helper to format an array of action data values into a unique key
+    // used for indexing the TpActionToEventMap dictionary.
+    public string FormatLookupKey(in string[] values) {
+      if (string.IsNullOrWhiteSpace(KeyFormatStr))
+        return string.Empty;
+      try { return string.Format(KeyFormatStr, values); }
+      catch { return string.Empty; }
+    }
+
+  }
+}

--- a/MSFSTouchPortalPlugin/Types/BooleanString.cs
+++ b/MSFSTouchPortalPlugin/Types/BooleanString.cs
@@ -1,0 +1,45 @@
+﻿using System.Runtime.InteropServices;
+using System.Text.RegularExpressions;
+
+namespace MSFSTouchPortalPlugin.Types
+{
+  /// <summary>
+  /// A boolean unmutable type which is set using a string value, converting
+  /// common English expressions for "truthiness" to a stored bool value.
+  /// `true` expressions are:
+  ///   any non-zero number, "true", "yes", "y", "on", "enable", "enabled"
+  /// It otherwise acts as a bool, also using its bool.ToString() for
+  /// string representation (not the string originally used to set the value).
+  /// It has implicit conversion operators to bool, int, uint, double, and string,
+  /// and can be assigned-to from those types as well.
+  /// The default value is False.
+  /// </summary>
+  internal readonly struct BooleanString
+  {
+    [MarshalAs(UnmanagedType.U1)]
+    private readonly bool _value;
+    private static readonly Regex _rx = new Regex(@"^(?:(?=[^1-9]*[1-9])(?=[\d.,-]).*|true|y(?:es)?|on|enabled?)$", RegexOptions.IgnoreCase);
+
+    public BooleanString(bool value) { _value = value; }
+    public BooleanString(string value = default) : this(StringToBool(value)) { }
+
+    public static bool StringToBool(string str) {
+      return !string.IsNullOrWhiteSpace(str) && _rx.IsMatch(str);
+    }
+
+    public static implicit operator BooleanString(string s) => new BooleanString(s);
+    public static implicit operator BooleanString(bool b) => new BooleanString(b);
+    public static implicit operator BooleanString(int i) => new BooleanString(i != 0);
+    public static implicit operator BooleanString(uint u) => new BooleanString(u != 0U);
+    public static implicit operator BooleanString(double d) => new BooleanString((int)d != 0);
+    public static implicit operator bool(BooleanString b) => b._value;
+    public static implicit operator int(BooleanString b) => b._value ? 1 : 0;
+    public static implicit operator uint(BooleanString b) => b._value ? 1U : 0U;
+    public static implicit operator double(BooleanString b) => b._value ? 1.0 : 0.0;
+    public static implicit operator string(BooleanString b) => b.ToString();
+
+    public override string ToString() => _value.ToString();
+    public override int GetHashCode() => _value.GetHashCode();
+    public override bool Equals(object obj) => _value.Equals(obj);
+  }
+}

--- a/MSFSTouchPortalPlugin/Types/PluginSetting.cs
+++ b/MSFSTouchPortalPlugin/Types/PluginSetting.cs
@@ -40,7 +40,7 @@ namespace MSFSTouchPortalPlugin.Types
     public void SetValueDynamic(dynamic value) {
       try {
         if (ValueType == DataType.Number) {
-          double realVal = Convert.ToDouble(value); ;
+          double realVal = Convert.ToDouble(value);
           if (!double.IsNaN(MinValue))
             realVal = Math.Max(realVal, MinValue);
           if (!double.IsNaN(MaxValue))

--- a/MSFSTouchPortalPlugin/Types/PluginSetting.cs
+++ b/MSFSTouchPortalPlugin/Types/PluginSetting.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using TouchPortalExtension.Enums;
 
-namespace MSFSTouchPortalPlugin.Objects.Plugin
+namespace MSFSTouchPortalPlugin.Types
 {
   public class PluginSetting
   {
@@ -31,7 +31,8 @@ namespace MSFSTouchPortalPlugin.Objects.Plugin
       if (ValueType == DataType.Number) {
         if (double.TryParse(value, out var numVal))
           Value = numVal;
-      } else {
+      }
+      else {
         Value = value;
       }
     }
@@ -59,7 +60,7 @@ namespace MSFSTouchPortalPlugin.Objects.Plugin
       }
     }
 
-    public int ValueAsInt() => (Value == null || ValueType != DataType.Number) ? 0 : (int)Value;
+    public int ValueAsInt() => Value == null || ValueType != DataType.Number ? 0 : (int)Value;
     public double ValueAsDbl() => Value == null ? double.NaN : (double)Value;
     public string ValueAsStr() => Value == null ? string.Empty : Value.ToString();
 

--- a/TouchPortalExtension/Attributes/TouchPortalActionAttribute.cs
+++ b/TouchPortalExtension/Attributes/TouchPortalActionAttribute.cs
@@ -1,14 +1,6 @@
 ﻿using System;
 
 namespace TouchPortalExtension.Attributes {
-  public enum DataType {
-    None,
-    Text,
-    Number,
-    Switch,
-    Choice
-  }
-
   [AttributeUsage(AttributeTargets.Field | AttributeTargets.Property)]
   public class TouchPortalActionAttribute : Attribute {
     public string Id { get; set; }

--- a/TouchPortalExtension/Enums/DataType.cs
+++ b/TouchPortalExtension/Enums/DataType.cs
@@ -1,0 +1,11 @@
+﻿namespace TouchPortalExtension.Enums
+{
+  public enum DataType
+  {
+    None,
+    Text,
+    Number,
+    Switch,
+    Choice
+  }
+}

--- a/TouchPortalExtension/TouchPortalExtension.csproj
+++ b/TouchPortalExtension/TouchPortalExtension.csproj
@@ -11,4 +11,8 @@
     <AdditionalFiles Include="..\.sonarlint\msfstouchportalplugin\CSharp\SonarLint.xml" Link="SonarLint.xml" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
* Added support for sending numeric data values to the simulator with the various "Set" actions.
  * Most/all "Set" actions have been broken out into their own separate action types. Since they now have a data field, it doesn't make sense to pair them with actions which don't use them, such as "Increment."
    * Buttons which did *not* use the old "Set" choices, such as "Increment," etc, will continue to work (although they will still show the old choices in existing TP buttons until replaced with the new versions). However any buttons which relied on the old behavior of the "Set" action value always being `0` (zero) will need to be updated.
  * Simple arithmetic operations (`+`, `-`, `*`, `/`, `%`, precedence with `( )`, scientific notation) are supported in most of the data fields which can be sent to the sim. 
That means you can do things like `25 * 30`, but more interestingly one could use states/variables, like:  
    `"AP Set Alt. Hold to:" ${value:MSFSTouchPortalPlugin.AutoPilot.State.AutoPilotAltitudeVar} + 1000`  
This evaluation could be expanded upon later if there is a need (to include higher math, rounding, etc).
* Generated documentation updated to include all Action Data attributes and mappings to the actual SimConnect events. Also added SimVar names to the list of States.
* New TP UI color for MSFS Plugin actions, "MSFS Blue"  ![msfs-blue](https://user-images.githubusercontent.com/1366615/153997641-e0bf23c4-2a19-4844-aa0a-53be8954119f.png)
* Action-to-event mapping syntax/scheme somewhat simplified and consolidated, for easier additions and maintenance. Now also allows custom event names (with a dot).
* Added new actions:
  * AP Set Airspeed Hold Value
  * AP Set Altitude Hold Value
  * AP Set Heading Hold Value
  * AP Set Mach Hold Value
  * AP Set Vertical Speed Hold Value
  * Magneto Switch 1/2/3/4 Set Position (0-4)
  * Propeller All/1/2/3/4 Set Pitch Lever Value (0 to 16383)
  * Throttle All/1/2/3/4 Set (-16383 - +16383)
  * Engine 1/2/3/4 Anti-ice Switch Set On/Off
  * Aileron Trim Set % (-100 - +100)
  * Ailerons Position Set (-16383 - +16383)
  * Elevator Trim Set (0 - 16383)
  * Elevator Position Set (-16383 - +16383)
  * Elevator Increment Up/Down
  * Rudder Trim Set % (-100 - +100)
  * Rudder Position Set (-16383 - +16383)
  * Flaps Position Set (0 - 16383)
  * Spoilers Position Set (0 - 16383)
* Modified actions:
  * Toggle Flight Director removed useless choice selector with the one "toggle" option (there are no SimConnect events for specific on/off), **BREAKS CURRENT BUTTONS**
  * Vertical Speed Hold added On/Off choices (in addition to Toggle which was the only one)
  * Vertical Speed Value removed "Set Current" choice since there's no such Sim event to map to
  * AP Nav Mode Switch 1/2, which never worked, now takes a value of 1 or 2 (that's how we have to set it up for now)
  * Toggle All Magnetos - added new "Select for +/-" choice
  * Engine Anti Ice Toggle removed Set choice (new action, above) which left only Toggle as 2nd choice, so that was removed **BREAKS CURRENT BUTTONS**
  * Held Action Repeat Rate changed entirely, can now be Set to a specific value or Increment/Decrement by any step amount (in ms)
 