### PR TITLE
Add "connecting" status for Plugin Connected state

### DIFF
--- a/MSFSTouchPortalPlugin/Objects/Plugin/Plugin.cs
+++ b/MSFSTouchPortalPlugin/Objects/Plugin/Plugin.cs
@@ -12,7 +12,7 @@ namespace MSFSTouchPortalPlugin.Objects.Plugin
     [TouchPortalActionMapping("ToggleConnection", "Toggle")]
     [TouchPortalActionMapping("Connect", "On")]
     [TouchPortalActionMapping("Disconnect", "Off")]
-    [TouchPortalState("Connected", "text", "The status of SimConnect", "false")]
+    [TouchPortalState("Connected", "text", "The status of SimConnect (true/false/connecting)", "false")]
     public static readonly object Connection;
   }
 

--- a/MSFSTouchPortalPlugin/Services/PluginService.cs
+++ b/MSFSTouchPortalPlugin/Services/PluginService.cs
@@ -167,7 +167,7 @@ namespace MSFSTouchPortalPlugin.Services {
     private void SimConnectEvent_OnConnect() {
       _simConnectCancellationTokenSource = new CancellationTokenSource();
 
-      _client.StateUpdate("MSFSTouchPortalPlugin.Plugin.State.Connected", _simConnectService.IsConnected().ToString().ToLower());
+      UpdateSimConnectState();
 
       // Register Actions
       var eventMap = _reflectionService.GetClientEventIdToNameMap();
@@ -221,7 +221,7 @@ namespace MSFSTouchPortalPlugin.Services {
     private void SimConnectEvent_OnDisconnect() {
       _simConnectCancellationTokenSource?.Cancel();
       ClearRepeatingActions();
-      _client.StateUpdate("MSFSTouchPortalPlugin.Plugin.State.Connected", _simConnectService.IsConnected().ToString().ToLower());
+      UpdateSimConnectState();
     }
 
     #endregion
@@ -275,14 +275,19 @@ namespace MSFSTouchPortalPlugin.Services {
           autoReconnectSimConnect = !autoReconnectSimConnect;
           if (_simConnectService.IsConnected())
             _simConnectService.Disconnect();
+          else
+            UpdateSimConnectState();
           break;
         case Plugin.Connect:
           autoReconnectSimConnect = true;
+          UpdateSimConnectState();
           break;
         case Plugin.Disconnect:
           autoReconnectSimConnect = false;
           if (_simConnectService.IsConnected())
             _simConnectService.Disconnect();
+          else
+            UpdateSimConnectState();
           break;
 
         case Plugin.ActionRepeatIntervalInc:
@@ -373,6 +378,13 @@ namespace MSFSTouchPortalPlugin.Services {
             _client.StateUpdate(setting.TouchPortalStateId, setting.ValueAsStr());
         }
       }
+    }
+
+    private void UpdateSimConnectState() {
+      string stat = "true";
+      if (!_simConnectService.IsConnected())
+        stat = autoReconnectSimConnect ? "connecting" : "false";
+      _client.StateUpdate("MSFSTouchPortalPlugin.Plugin.State.Connected", stat);
     }
 
     #region TouchPortalSDK Events


### PR DESCRIPTION
For Plugin.State.Connected add "connecting" status which is active while SimConnect is not connected but is trying to be. "false" now indicates that it is disconnected and no attempts are being made to connect.

**Possibly breaks current buttons** if they rely specifically on the "false" status string (still fine if checking for `!"true"` like @HiDTH's pages do).

The issue, I realized, is that unless staring at the debug console while testing, there's no indication that the plugin is still trying to connect to the sim in the background while the sim isn't running (or crashed or whatever).  One could toggle the connection off,, which would in fact stop the connection attempts, but there was no indication that anything changed.

Here's how I use it:

![image](https://user-images.githubusercontent.com/1366615/154907314-2f8db22a-c467-41f4-82d1-7812bf11f003.png)
